### PR TITLE
feat: implement universal search API with PostgreSQL full-text indexing

### DIFF
--- a/packages/backend/src/search/dto/search.dto.ts
+++ b/packages/backend/src/search/dto/search.dto.ts
@@ -1,0 +1,39 @@
+import { IsString, IsNotEmpty, MinLength } from 'class-validator';
+
+export class SearchQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  q: string;
+}
+
+export class UserSearchResult {
+  id: string;
+  displayName: string;
+  address: string;
+  avatar?: string;
+}
+
+export class CallSearchResult {
+  id: string;
+  title: string;
+  description: string;
+  createdAt: Date;
+}
+
+export class TokenSearchResult {
+  id: string;
+  name: string;
+  symbol: string;
+  address: string;
+}
+
+export class SearchResponseDto {
+  users: UserSearchResult[];
+  calls: CallSearchResult[];
+  tokens: TokenSearchResult[];
+  meta: {
+    query: string;
+    total: number;
+  };
+}

--- a/packages/backend/src/search/search.controller.ts
+++ b/packages/backend/src/search/search.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { SearchQueryDto, SearchResponseDto } from './dto/search.dto';
+
+@Controller('search')
+export class SearchController {
+  constructor(private readonly searchService: SearchService) {}
+
+  @Get()
+  async search(@Query() query: SearchQueryDto): Promise<SearchResponseDto> {
+    return this.searchService.search(query.q);
+  }
+}

--- a/packages/backend/src/search/search.module.ts
+++ b/packages/backend/src/search/search.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+
+@Module({
+  controllers: [SearchController],
+  providers: [SearchService],
+})
+export class SearchModule {}

--- a/packages/backend/src/search/search.service.ts
+++ b/packages/backend/src/search/search.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import {
+  SearchResponseDto,
+  UserSearchResult,
+  CallSearchResult,
+  TokenSearchResult,
+} from './dto/search.dto';
+
+@Injectable()
+export class SearchService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async search(query: string): Promise<SearchResponseDto> {
+    const sanitized = query.trim();
+
+    const [users, calls, tokens] = await Promise.all([
+      this.searchUsers(sanitized),
+      this.searchCalls(sanitized),
+      this.searchTokens(sanitized),
+    ]);
+
+    return {
+      users,
+      calls,
+      tokens,
+      meta: {
+        query: sanitized,
+        total: users.length + calls.length + tokens.length,
+      },
+    };
+  }
+
+  private async searchUsers(query: string): Promise<UserSearchResult[]> {
+    const tsQuery = this.toTsQuery(query);
+
+    const results = await this.dataSource.query(
+      `
+      SELECT
+        u.id,
+        u."displayName",
+        u.address,
+        u.avatar
+      FROM "user" u
+      WHERE
+        to_tsvector('english', coalesce(u."displayName", '') || ' ' || coalesce(u.address, ''))
+          @@ plainto_tsquery('english', $1)
+        OR u."displayName" ILIKE $2
+        OR u.address ILIKE $2
+      ORDER BY
+        ts_rank(
+          to_tsvector('english', coalesce(u."displayName", '') || ' ' || coalesce(u.address, '')),
+          plainto_tsquery('english', $1)
+        ) DESC
+      LIMIT 10
+      `,
+      [tsQuery, `%${query}%`],
+    );
+
+    return results.map((r: any) => ({
+      id: r.id,
+      displayName: r.displayName,
+      address: r.address,
+      avatar: r.avatar ?? null,
+    }));
+  }
+
+  private async searchCalls(query: string): Promise<CallSearchResult[]> {
+    const tsQuery = this.toTsQuery(query);
+
+    const results = await this.dataSource.query(
+      `
+      SELECT
+        c.id,
+        c.title,
+        c.description,
+        c."createdAt"
+      FROM "call" c
+      WHERE
+        to_tsvector('english', coalesce(c.title, '') || ' ' || coalesce(c.description, ''))
+          @@ plainto_tsquery('english', $1)
+        OR c.title ILIKE $2
+        OR c.description ILIKE $2
+      ORDER BY
+        ts_rank(
+          to_tsvector('english', coalesce(c.title, '') || ' ' || coalesce(c.description, '')),
+          plainto_tsquery('english', $1)
+        ) DESC
+      LIMIT 10
+      `,
+      [tsQuery, `%${query}%`],
+    );
+
+    return results.map((r: any) => ({
+      id: r.id,
+      title: r.title,
+      description: r.description,
+      createdAt: r.createdAt,
+    }));
+  }
+
+  private async searchTokens(query: string): Promise<TokenSearchResult[]> {
+    const tsQuery = this.toTsQuery(query);
+
+    const results = await this.dataSource.query(
+      `
+      SELECT
+        t.id,
+        t.name,
+        t.symbol,
+        t.address
+      FROM "token" t
+      WHERE
+        to_tsvector('english', coalesce(t.name, '') || ' ' || coalesce(t.symbol, ''))
+          @@ plainto_tsquery('english', $1)
+        OR t.name ILIKE $2
+        OR t.symbol ILIKE $2
+        OR t.address ILIKE $2
+      ORDER BY
+        ts_rank(
+          to_tsvector('english', coalesce(t.name, '') || ' ' || coalesce(t.symbol, '')),
+          plainto_tsquery('english', $1)
+        ) DESC
+      LIMIT 10
+      `,
+      [tsQuery, `%${query}%`],
+    );
+
+    return results.map((r: any) => ({
+      id: r.id,
+      name: r.name,
+      symbol: r.symbol,
+      address: r.address,
+    }));
+  }
+
+  private toTsQuery(query: string): string {
+    return query
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => word.replace(/[^a-zA-Z0-9]/g, ''))
+      .filter(Boolean)
+      .join(' & ');
+  }
+}


### PR DESCRIPTION
Description:
  Adds a global search endpoint that queries Users, Calls, and Tokens concurrently.

  - GET /search?q= returns results grouped by entity type
  - Uses PostgreSQL tsvector/tsquery for full-text search with ts_rank ordering
  - ILIKE fallback ensures partial/fuzzy matches are captured
  - All three entity searches run in parallel via Promise.all
  - Located at packages/backend/src/search
  
  closes #39 