### PR TITLE
feat(backend): add RPC exponential backoff retry and production-readyDB migration pipeline

### DIFF
--- a/packages/backend/src/common/rpc/rpc-retry.util.ts
+++ b/packages/backend/src/common/rpc/rpc-retry.util.ts
@@ -1,0 +1,242 @@
+/**
+ * rpc-retry.util.ts
+ *
+ * Framework-agnostic exponential-backoff retry engine for Soroban RPC calls.
+ * Used directly by the RetryableService helper and the @Retryable() decorator.
+ *
+ * Backoff schedule (default, base 1 s, factor 2, jitter ±20 %):
+ *   Attempt 1 → immediate
+ *   Attempt 2 → ~1 000 ms
+ *   Attempt 3 → ~2 000 ms
+ *   Attempt 4 → ~4 000 ms
+ *   Attempt 5 → throws RpcExhaustedError
+ */
+
+import { Logger } from '@nestjs/common';
+
+// ─── Error types ────────────────────────────────────────────────────────────
+
+/** Thrown when every retry attempt has been exhausted. */
+export class RpcExhaustedError extends Error {
+  constructor(
+    public readonly operation: string,
+    public readonly attempts: number,
+    public readonly lastError: Error,
+  ) {
+    super(
+      `RPC operation "${operation}" failed after ${attempts} attempt(s): ${lastError.message}`,
+    );
+    this.name = 'RpcExhaustedError';
+  }
+}
+
+/** Thrown by a predicate to signal that retrying is futile (e.g. 4xx logic error). */
+export class RpcNonRetryableError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'RpcNonRetryableError';
+  }
+}
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+export interface RetryOptions {
+  /**
+   * Maximum number of *total* attempts (including the first call).
+   * @default 4
+   */
+  maxAttempts?: number;
+
+  /**
+   * Base delay in milliseconds. Each retry waits `baseDelayMs * (factor ^ attempt)`.
+   * @default 1000
+   */
+  baseDelayMs?: number;
+
+  /**
+   * Exponential growth factor.
+   * @default 2
+   */
+  factor?: number;
+
+  /**
+   * Maximum delay cap in milliseconds — prevents runaway waits on high attempt counts.
+   * @default 30_000
+   */
+  maxDelayMs?: number;
+
+  /**
+   * Fractional jitter applied to each delay to avoid thundering-herd on multiple callers.
+   * 0.2 means ±20% of the computed delay.
+   * @default 0.2
+   */
+  jitter?: number;
+
+  /**
+   * Optional predicate — return `false` to skip retrying for a specific error
+   * (e.g. a 400 Bad Request is a logic error, not a transient network issue).
+   */
+  isRetryable?: (err: Error, attempt: number) => boolean;
+
+  /**
+   * Label used in log messages — typically the method or operation name.
+   */
+  operationName?: string;
+}
+
+const DEFAULTS = {
+  maxAttempts: 4,
+  baseDelayMs: 1_000,
+  factor: 2,
+  maxDelayMs: 30_000,
+  jitter: 0.2,
+} as const;
+
+// ─── Core implementation ─────────────────────────────────────────────────────
+
+const logger = new Logger('RpcRetry');
+
+/**
+ * Executes `fn` with exponential-backoff retry logic.
+ *
+ * @param fn      Async function to execute. May be called up to `maxAttempts` times.
+ * @param options Retry configuration.
+ * @returns       The resolved value of `fn` on success.
+ * @throws        `RpcExhaustedError` if all attempts fail.
+ * @throws        `RpcNonRetryableError` (re-thrown immediately, no more retries).
+ *
+ * @example
+ * const result = await withRetry(
+ *   () => sorobanRpc.getContractData(key),
+ *   { operationName: 'getContractData', maxAttempts: 5 },
+ * );
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = DEFAULTS.maxAttempts,
+    baseDelayMs = DEFAULTS.baseDelayMs,
+    factor = DEFAULTS.factor,
+    maxDelayMs = DEFAULTS.maxDelayMs,
+    jitter = DEFAULTS.jitter,
+    isRetryable,
+    operationName = 'rpc',
+  } = options;
+
+  let lastError: Error = new Error('Unknown error');
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+
+      // Non-retryable errors bubble up immediately
+      if (lastError instanceof RpcNonRetryableError) throw lastError;
+
+      // Caller-supplied predicate
+      if (isRetryable && !isRetryable(lastError, attempt)) {
+        throw new RpcNonRetryableError(
+          `Non-retryable error on "${operationName}": ${lastError.message}`,
+          lastError,
+        );
+      }
+
+      if (attempt === maxAttempts) break; // don't sleep on the final failure
+
+      const rawDelay = Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
+      const jitterMs = rawDelay * jitter * (Math.random() * 2 - 1); // ±jitter%
+      const delay = Math.max(0, Math.round(rawDelay + jitterMs));
+
+      logger.warn(
+        `[${operationName}] attempt ${attempt}/${maxAttempts} failed — ` +
+          `retrying in ${delay}ms. Error: ${lastError.message}`,
+      );
+
+      await sleep(delay);
+    }
+  }
+
+  throw new RpcExhaustedError(operationName, maxAttempts, lastError);
+}
+
+/** Convenience: build a pre-configured retry wrapper for a fixed set of options. */
+export function createRetryFn(defaults: RetryOptions) {
+  return <T>(fn: () => Promise<T>, overrides: RetryOptions = {}): Promise<T> =>
+    withRetry(fn, { ...defaults, ...overrides });
+}
+
+// ─── RxJS integration ────────────────────────────────────────────────────────
+
+/**
+ * Returns an RxJS `RetryConfig` object compatible with `retry({ delay: ... })`.
+ * Use this when the Soroban client wraps calls in Observables.
+ *
+ * @example
+ * import { retry } from 'rxjs';
+ * sorobanObservable$.pipe(retry(sorobanRetryConfig())).subscribe(...)
+ */
+export function sorobanRetryConfig(options: RetryOptions = {}) {
+  const {
+    maxAttempts = DEFAULTS.maxAttempts,
+    baseDelayMs = DEFAULTS.baseDelayMs,
+    factor = DEFAULTS.factor,
+    maxDelayMs = DEFAULTS.maxDelayMs,
+    jitter = DEFAULTS.jitter,
+    operationName = 'rpc',
+  } = options;
+
+  // Imported lazily so this file stays usable in projects without rxjs
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { timer, throwError } = require('rxjs') as typeof import('rxjs');
+
+  return {
+    count: maxAttempts - 1, // rxjs counts retries, not total attempts
+    delay: (error: Error, retryIndex: number) => {
+      if (error instanceof RpcNonRetryableError) return throwError(() => error);
+
+      const rawDelay = Math.min(baseDelayMs * Math.pow(factor, retryIndex - 1), maxDelayMs);
+      const jitterMs = rawDelay * jitter * (Math.random() * 2 - 1);
+      const delay = Math.max(0, Math.round(rawDelay + jitterMs));
+
+      logger.warn(
+        `[${operationName}] RxJS retry ${retryIndex}/${maxAttempts - 1} — ` +
+          `waiting ${delay}ms. Error: ${(error as Error).message}`,
+      );
+
+      return timer(delay);
+    },
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Default retryability predicate for Soroban RPC errors.
+ * Treats 4xx responses (except 429 Too Many Requests) as non-retryable.
+ */
+export function defaultSorobanIsRetryable(err: Error): boolean {
+  const msg = err.message.toLowerCase();
+
+  // Rate-limit (429) → always retry
+  if (msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')) {
+    return true;
+  }
+
+  // Other 4xx client errors → logic/auth errors, no point retrying
+  if (/\b4[0-9]{2}\b/.test(msg) && !msg.includes('408') && !msg.includes('425')) {
+    return false;
+  }
+
+  // Network / 5xx / timeout → retryable
+  return true;
+}

--- a/packages/backend/src/config/rpc.module.ts
+++ b/packages/backend/src/config/rpc.module.ts
@@ -1,0 +1,17 @@
+import { Module, Global } from '@nestjs/common';
+import { SorobanRpcClient } from './soroban-rpc.client';
+
+/**
+ * RpcModule
+ *
+ * Marked @Global so that SorobanRpcClient is available for injection in
+ * IndexerModule, OracleModule, and any future module without re-importing.
+ *
+ * Add to AppModule.imports once.
+ */
+@Global()
+@Module({
+  providers: [SorobanRpcClient],
+  exports: [SorobanRpcClient],
+})
+export class RpcModule {}

--- a/packages/backend/src/config/soroban-rpc.client.ts
+++ b/packages/backend/src/config/soroban-rpc.client.ts
@@ -1,0 +1,224 @@
+/**
+ * soroban-rpc.client.ts
+ *
+ * Thin wrapper around the Stellar SDK's SorobanRpc module that:
+ *  1. Centralises all outbound Soroban RPC calls in one place.
+ *  2. Applies @Retryable() with Soroban-appropriate defaults to every method.
+ *  3. Exposes a clean interface so IndexerService and OracleService never
+ *     touch the raw SDK client directly.
+ *
+ * Install deps:
+ *   npm install @stellar/stellar-sdk
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SorobanRpc, Contract, xdr, scValToNative, Address } from '@stellar/stellar-sdk';
+import { Retryable } from '../decorators/retryable.decorator';
+import { defaultSorobanIsRetryable, RpcExhaustedError } from '../rpc/rpc-retry.util';
+
+export interface SorobanEvent {
+  id: string;
+  type: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  contractId: string;
+  topic: unknown[];
+  value: unknown;
+}
+
+export interface ContractDataResult {
+  key: string;
+  value: unknown;
+  lastModifiedLedger: number;
+}
+
+@Injectable()
+export class SorobanRpcClient implements OnModuleInit {
+  private readonly logger = new Logger(SorobanRpcClient.name);
+  private rpc: SorobanRpc.Server;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    const rpcUrl = this.config.get<string>('SOROBAN_RPC_URL', 'https://soroban-testnet.stellar.org');
+    this.rpc = new SorobanRpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
+    this.logger.log(`Soroban RPC client initialised → ${rpcUrl}`);
+  }
+
+  // ─── Health / connectivity ──────────────────────────────────────────────
+
+  @Retryable({ maxAttempts: 3, operationName: 'soroban:getHealth' })
+  async getHealth(): Promise<SorobanRpc.Api.GetHealthResponse> {
+    return this.rpc.getHealth();
+  }
+
+  @Retryable({ maxAttempts: 3, operationName: 'soroban:getLatestLedger' })
+  async getLatestLedger(): Promise<SorobanRpc.Api.GetLatestLedgerResponse> {
+    return this.rpc.getLatestLedger();
+  }
+
+  // ─── Contract data reads ─────────────────────────────────────────────────
+
+  /**
+   * Reads a single persistent contract data entry by XDR key.
+   * Used by OracleService to read on-chain oracle prices and quorum config.
+   */
+  @Retryable({
+    maxAttempts: 4,
+    baseDelayMs: 1_000,
+    isRetryable: defaultSorobanIsRetryable,
+    operationName: 'soroban:getContractData',
+  })
+  async getContractData(
+    contractId: string,
+    key: xdr.ScVal,
+    durability: SorobanRpc.Api.Durability = SorobanRpc.Api.Durability.Persistent,
+  ): Promise<ContractDataResult | null> {
+    try {
+      const response = await this.rpc.getContractData(contractId, key, durability);
+
+      if (!response?.val) return null;
+
+      return {
+        key: key.toXDR('base64'),
+        value: scValToNative(response.val.val()),
+        lastModifiedLedger: response.lastModifiedLedgerSeq,
+      };
+    } catch (err) {
+      // "entry not found" is not a network error — don't retry
+      if ((err as Error).message?.includes('not found')) return null;
+      throw err;
+    }
+  }
+
+  // ─── Event fetching ──────────────────────────────────────────────────────
+
+  /**
+   * Fetches contract events in a ledger range.
+   * Used by IndexerService to ingest stake / market events.
+   */
+  @Retryable({
+    maxAttempts: 5,
+    baseDelayMs: 1_000,
+    isRetryable: defaultSorobanIsRetryable,
+    operationName: 'soroban:getEvents',
+  })
+  async getEvents(params: {
+    startLedger: number;
+    contractIds: string[];
+    eventTypes?: ('contract' | 'system' | 'diagnostic')[];
+    limit?: number;
+  }): Promise<SorobanEvent[]> {
+    const { startLedger, contractIds, eventTypes = ['contract'], limit = 200 } = params;
+
+    const filters: SorobanRpc.Api.EventFilter[] = contractIds.map((id) => ({
+      type: eventTypes[0] as SorobanRpc.Api.EventFilter['type'],
+      contractIds: [id],
+    }));
+
+    const response = await this.rpc.getEvents({
+      startLedger,
+      filters,
+      limit,
+    });
+
+    return (response.events ?? []).map((e) => ({
+      id: e.id,
+      type: e.type,
+      ledger: e.ledger,
+      ledgerClosedAt: e.ledgerClosedAt,
+      contractId: e.contractId,
+      topic: e.topic.map(scValToNative),
+      value: scValToNative(e.value),
+    }));
+  }
+
+  // ─── Transaction submission ──────────────────────────────────────────────
+
+  /**
+   * Simulates a transaction (read-only) and returns the result.
+   * OracleService uses this to invoke view functions on CallRegistry.
+   */
+  @Retryable({
+    maxAttempts: 4,
+    baseDelayMs: 1_000,
+    isRetryable: defaultSorobanIsRetryable,
+    operationName: 'soroban:simulateTransaction',
+  })
+  async simulateTransaction(
+    transaction: Parameters<SorobanRpc.Server['simulateTransaction']>[0],
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse> {
+    return this.rpc.simulateTransaction(transaction);
+  }
+
+  /**
+   * Submits a signed transaction and polls for its result.
+   * OutcomeManager calls this for manual resolution transactions.
+   */
+  @Retryable({
+    maxAttempts: 4,
+    baseDelayMs: 2_000,
+    isRetryable: defaultSorobanIsRetryable,
+    operationName: 'soroban:sendTransaction',
+  })
+  async sendTransaction(
+    transaction: Parameters<SorobanRpc.Server['sendTransaction']>[0],
+  ): Promise<SorobanRpc.Api.SendTransactionResponse> {
+    return this.rpc.sendTransaction(transaction);
+  }
+
+  /**
+   * Polls transaction status until it is final (SUCCESS / FAILED / timeout).
+   * Retried separately from send because a successful send may still need polling.
+   */
+  @Retryable({
+    maxAttempts: 10,
+    baseDelayMs: 2_000,
+    factor: 1.5,
+    maxDelayMs: 15_000,
+    operationName: 'soroban:getTransaction',
+  })
+  async getTransaction(
+    hash: string,
+  ): Promise<SorobanRpc.Api.GetTransactionResponse> {
+    const result = await this.rpc.getTransaction(hash);
+    // NOT_FOUND means still pending — treat as retriable
+    if (result.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      throw new Error(`Transaction ${hash} still pending (NOT_FOUND)`);
+    }
+    return result;
+  }
+
+  // ─── Convenience: send and wait ──────────────────────────────────────────
+
+  /**
+   * Submits a transaction and polls until a terminal status is reached.
+   * Combines sendTransaction + getTransaction into a single awaitable call.
+   */
+  async sendAndConfirm(
+    transaction: Parameters<SorobanRpc.Server['sendTransaction']>[0],
+    timeoutMs = 60_000,
+  ): Promise<SorobanRpc.Api.GetTransactionResponse> {
+    const sendResult = await this.sendTransaction(transaction);
+
+    if (sendResult.status === 'ERROR') {
+      throw new RpcExhaustedError(
+        'soroban:sendTransaction',
+        1,
+        new Error(`Send failed: ${JSON.stringify(sendResult.errorResult)}`),
+      );
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        return await this.getTransaction(sendResult.hash);
+      } catch {
+        // still pending — getTransaction retry handles the wait
+      }
+    }
+
+    throw new Error(`Transaction ${sendResult.hash} did not confirm within ${timeoutMs}ms`);
+  }
+}

--- a/packages/backend/src/data-source.ts
+++ b/packages/backend/src/data-source.ts
@@ -1,0 +1,59 @@
+/**
+ * data-source.ts
+ *
+ * The canonical TypeORM DataSource used by:
+ *   1. The TypeORM CLI  (typeorm:generate, typeorm:run, typeorm:revert)
+ *   2. AppModule at runtime via TypeOrmModule.forRootAsync()
+ *
+ * Having one file eliminates config drift between the CLI and the app.
+ *
+ * Usage:
+ *   npx typeorm-ts-node-commonjs -d src/data-source.ts migration:run
+ *   (or use the npm scripts defined in package.json)
+ */
+
+import { DataSource, DataSourceOptions } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+// Load .env before anything else so process.env is populated for the CLI
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+export const dataSourceOptions: DataSourceOptions = {
+  type: 'postgres',
+
+  // ── Connection ────────────────────────────────────────────────────────────
+  host:     process.env.DB_HOST     || process.env.POSTGRES_HOST     || 'localhost',
+  port:     parseInt(process.env.DB_PORT || process.env.POSTGRES_PORT || '5432', 10),
+  username: process.env.DB_USERNAME || process.env.POSTGRES_USER     || 'postgres',
+  password: process.env.DB_PASSWORD || process.env.POSTGRES_PASSWORD || 'postgres',
+  database: process.env.DB_NAME     || process.env.POSTGRES_DB       || 'backit',
+
+  // ── Schema management ─────────────────────────────────────────────────────
+  // synchronize is ALWAYS false here — migrations are the only way schema changes.
+  synchronize: false,
+  migrationsRun: false, // run explicitly via CLI or startup hook, never silently
+
+  // ── Entity discovery ──────────────────────────────────────────────────────
+  // Glob picks up every *.entity.ts in the src tree, so new entities are
+  // automatically included without touching this file.
+  entities: [
+    path.join(__dirname, '**', '*.entity.{ts,js}'),
+  ],
+
+  // ── Migrations ────────────────────────────────────────────────────────────
+  migrations: [
+    path.join(__dirname, 'migrations', '*.{ts,js}'),
+  ],
+  migrationsTableName: 'typeorm_migrations', // explicit name prevents accidental conflicts
+
+  // ── Logging ───────────────────────────────────────────────────────────────
+  // Log all queries in development; only errors in production.
+  logging: process.env.NODE_ENV === 'production' ? ['error'] : ['error', 'warn', 'schema'],
+};
+
+/**
+ * Default export — required by the TypeORM CLI (`-d src/data-source.ts`).
+ */
+const AppDataSource = new DataSource(dataSourceOptions);
+export default AppDataSource;

--- a/packages/backend/src/decorators/retryable.decorator.ts
+++ b/packages/backend/src/decorators/retryable.decorator.ts
@@ -1,0 +1,81 @@
+/**
+ * retryable.decorator.ts
+ *
+ * Method decorator that wraps any async class method with exponential-backoff
+ * retry logic. Works on NestJS service methods or any plain TypeScript class.
+ *
+ * Usage:
+ *
+ * @Retryable(3)
+ * async fetchEvents() { ... }
+ *
+ * @Retryable({ maxAttempts: 5, baseDelayMs: 500, operationName: 'fetchOraclePrice' })
+ * async getOraclePrice() { ... }
+ */
+
+import { withRetry, RetryOptions, defaultSorobanIsRetryable } from '../rpc/rpc-retry.util';
+
+/**
+ * @Retryable(maxAttempts)
+ * @Retryable(options)
+ *
+ * Decorates an async method to automatically retry on failure using
+ * exponential backoff with jitter.
+ *
+ * The `operationName` defaults to `ClassName.methodName` if not provided.
+ *
+ * @example
+ * // Simple — 3 total attempts, all other defaults
+ * @Retryable(3)
+ * async fetchContractState(key: string): Promise<string> {
+ *   return this.sorobanRpc.getContractData(key);
+ * }
+ *
+ * @example
+ * // Full config — custom backoff, non-retryable predicate
+ * @Retryable({
+ *   maxAttempts: 5,
+ *   baseDelayMs: 500,
+ *   isRetryable: defaultSorobanIsRetryable,
+ *   operationName: 'oracle:getPrice',
+ * })
+ * async getPrice(asset: string): Promise<number> {
+ *   return this.rpcClient.simulateTransaction(...);
+ * }
+ */
+export function Retryable(optionsOrMaxAttempts: number | RetryOptions) {
+  const options: RetryOptions =
+    typeof optionsOrMaxAttempts === 'number'
+      ? {
+          maxAttempts: optionsOrMaxAttempts,
+          isRetryable: defaultSorobanIsRetryable,
+        }
+      : {
+          isRetryable: defaultSorobanIsRetryable,
+          ...optionsOrMaxAttempts,
+        };
+
+  return function (
+    target: object,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ): PropertyDescriptor {
+    const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
+
+    // Build a human-readable operation name for log messages
+    const className = target.constructor?.name ?? 'Unknown';
+    const operationName = options.operationName ?? `${className}.${propertyKey}`;
+
+    descriptor.value = async function (...args: unknown[]) {
+      return withRetry(() => originalMethod.apply(this, args), {
+        ...options,
+        operationName,
+      });
+    };
+
+    // Preserve the method name for stack traces and Reflect metadata
+    Object.defineProperty(descriptor.value, 'name', { value: propertyKey });
+
+    return descriptor;
+  };
+}

--- a/packages/backend/src/importing/rpc-retry.spec.ts
+++ b/packages/backend/src/importing/rpc-retry.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * rpc-retry.spec.ts
+ *
+ * Unit tests for the exponential-backoff retry engine.
+ * Run with: npx jest rpc-retry --testPathPattern src/common
+ */
+
+import {
+  withRetry,
+  RpcExhaustedError,
+  RpcNonRetryableError,
+  defaultSorobanIsRetryable,
+} from '../rpc/rpc-retry.util';
+import { Retryable } from '../decorators/retryable.decorator';
+
+// ── Suppress logger noise in tests ──────────────────────────────────────────
+jest.mock('@nestjs/common', () => {
+  const actual = jest.requireActual<typeof import('@nestjs/common')>('@nestjs/common');
+  return {
+    ...actual,
+    Logger: class {
+      warn = jest.fn();
+      error = jest.fn();
+      log = jest.fn();
+      debug = jest.fn();
+    },
+  };
+});
+
+// Speed up tests — override sleep
+jest.useFakeTimers();
+
+async function drainPromises() {
+  // Flush microtasks then advance all pending timers repeatedly
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+  }
+}
+
+// ─── withRetry ───────────────────────────────────────────────────────────────
+
+describe('withRetry', () => {
+  it('resolves immediately when fn succeeds on first attempt', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const promise = withRetry(fn, { maxAttempts: 3 });
+    await drainPromises();
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries and eventually succeeds', async () => {
+    let calls = 0;
+    const fn = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 3) return Promise.reject(new Error('transient'));
+      return Promise.resolve('recovered');
+    });
+
+    const promise = withRetry(fn, { maxAttempts: 4, baseDelayMs: 100 });
+    await drainPromises();
+    await expect(promise).resolves.toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws RpcExhaustedError when all attempts fail', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('rpc down'));
+    const promise = withRetry(fn, { maxAttempts: 3, baseDelayMs: 100 });
+    await drainPromises();
+
+    await expect(promise).rejects.toThrow(RpcExhaustedError);
+    await expect(promise).rejects.toMatchObject({ attempts: 3 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry when RpcNonRetryableError is thrown', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValue(new RpcNonRetryableError('bad request'));
+
+    const promise = withRetry(fn, { maxAttempts: 4 });
+    await drainPromises();
+
+    await expect(promise).rejects.toThrow(RpcNonRetryableError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects isRetryable predicate', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('HTTP 400 bad request'));
+    const promise = withRetry(fn, {
+      maxAttempts: 4,
+      isRetryable: defaultSorobanIsRetryable,
+    });
+    await drainPromises();
+
+    // 400 is non-retryable — should throw immediately without 3 more attempts
+    await expect(promise).rejects.toThrow(RpcNonRetryableError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows 429 rate-limit errors to be retried', async () => {
+    let calls = 0;
+    const fn = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 3) return Promise.reject(new Error('HTTP 429 rate limit exceeded'));
+      return Promise.resolve('after rate limit');
+    });
+
+    const promise = withRetry(fn, {
+      maxAttempts: 4,
+      baseDelayMs: 100,
+      isRetryable: defaultSorobanIsRetryable,
+    });
+    await drainPromises();
+
+    await expect(promise).resolves.toBe('after rate limit');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ─── @Retryable decorator ────────────────────────────────────────────────────
+
+describe('@Retryable decorator', () => {
+  class FakeRpcService {
+    calls = 0;
+
+    @Retryable(3)
+    async callWithRetry(): Promise<string> {
+      this.calls++;
+      if (this.calls < 3) throw new Error('transient rpc error');
+      return 'success';
+    }
+
+    @Retryable({ maxAttempts: 2, baseDelayMs: 50 })
+    async alwaysFails(): Promise<never> {
+      throw new Error('permanently broken');
+    }
+  }
+
+  it('retries the method and returns result on success', async () => {
+    const svc = new FakeRpcService();
+    const promise = svc.callWithRetry();
+    await drainPromises();
+    await expect(promise).resolves.toBe('success');
+    expect(svc.calls).toBe(3);
+  });
+
+  it('throws RpcExhaustedError after maxAttempts', async () => {
+    const svc = new FakeRpcService();
+    const promise = svc.alwaysFails();
+    await drainPromises();
+    await expect(promise).rejects.toThrow(RpcExhaustedError);
+  });
+});
+
+// ─── defaultSorobanIsRetryable ───────────────────────────────────────────────
+
+describe('defaultSorobanIsRetryable', () => {
+  it.each([
+    ['network timeout', true],
+    ['ECONNREFUSED', true],
+    ['HTTP 500 Internal Server Error', true],
+    ['HTTP 503 service unavailable', true],
+    ['429 Too Many Requests', true],
+    ['HTTP 400 bad request', false],
+    ['HTTP 401 unauthorized', false],
+    ['HTTP 403 forbidden', false],
+    ['HTTP 404 not found', false],
+  ])('"%s" → retryable=%s', (message, expected) => {
+    expect(defaultSorobanIsRetryable(new Error(message))).toBe(expected);
+  });
+});

--- a/packages/backend/src/indexer/indexer.service.ts
+++ b/packages/backend/src/indexer/indexer.service.ts
@@ -1,15 +1,36 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ethers } from 'ethers';
 import { Call } from '../calls/call.entity';
 import { AuthService } from '../auth/auth.service';
+import { RpcExhaustedError, Retryable, withRetry } from '../oracle/oracle.service';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CALL_REGISTRY_ABI = [
+  'event CallCreated(uint256 indexed callId, address indexed creator, address stakeToken, uint256 stakeAmount, uint256 startTs, uint256 endTs, address tokenAddress, bytes32 pairId, string ipfsCID)',
+  'event StakeAdded(uint256 indexed callId, address indexed staker, bool position, uint256 amount)',
+];
+
+/** How long to wait before attempting to reconnect the live listener (ms). */
+const LISTENER_RECONNECT_DELAY_MS = 10_000;
+
+/** Maximum reconnect attempts before giving up on the live listener. */
+const LISTENER_MAX_RECONNECTS = 10;
+
+// ─── Service ──────────────────────────────────────────────────────────────────
 
 @Injectable()
 export class IndexerService implements OnModuleInit {
+  private readonly logger = new Logger(IndexerService.name);
+
   private provider: ethers.JsonRpcProvider;
   private registryAddress: string;
+
+  /** Tracks how many times the live listener has been reconnected. */
+  private reconnectCount = 0;
 
   constructor(
     private configService: ConfigService,
@@ -26,82 +47,135 @@ export class IndexerService implements OnModuleInit {
     }
   }
 
+  // ─── Lifecycle ─────────────────────────────────────────────────────────────
+
   async onModuleInit() {
-    if (this.provider && this.registryAddress) {
-      const network = await this.provider.getNetwork();
-      const blockNumber = await this.provider.getBlockNumber();
-      console.log(`[Indexer Debug] Connected to Chain ID: ${network.chainId}`);
-      console.log(`[Indexer Debug] Current Block: ${blockNumber}`);
-      console.log(
-        `[Indexer Debug] RPC URL: ${this.configService.get<string>('BASE_SEPOLIA_RPC_URL')}`,
+    if (!this.provider || !this.registryAddress) {
+      this.logger.warn(
+        'BASE_SEPOLIA_RPC_URL or CALL_REGISTRY_ADDRESS not set — indexer disabled',
+      );
+      return;
+    }
+
+    try {
+      // Both calls are retried internally via @Retryable
+      const [network, blockNumber] = await Promise.all([
+        this.getNetwork(),
+        this.getBlockNumber(),
+      ]);
+
+      this.logger.log(`Connected to Chain ID: ${network.chainId}`);
+      this.logger.log(`Current Block: ${blockNumber}`);
+      this.logger.log(
+        `RPC URL: ${this.configService.get<string>('BASE_SEPOLIA_RPC_URL')}`,
       );
 
       await this.syncHistoricalEvents();
       this.startListening();
+    } catch (err) {
+      // If even the retried init calls fail, log and leave the indexer offline
+      // rather than crashing the whole application.
+      this.logger.error(
+        `Indexer failed to initialise after retries: ${(err as Error).message}`,
+      );
     }
   }
 
-  async syncHistoricalEvents() {
-    console.log('Syncing historical events...');
-    const abi = [
-      'event CallCreated(uint256 indexed callId, address indexed creator, address stakeToken, uint256 stakeAmount, uint256 startTs, uint256 endTs, address tokenAddress, bytes32 pairId, string ipfsCID)',
-      'event StakeAdded(uint256 indexed callId, address indexed staker, bool position, uint256 amount)',
-    ];
+  // ─── Retried RPC primitives ────────────────────────────────────────────────
+
+  /**
+   * Fetches the connected network info.
+   * Retried up to 4 times with exponential backoff before throwing.
+   */
+  @Retryable({ maxAttempts: 4, operationName: 'indexer:getNetwork' })
+  private async getNetwork(): Promise<ethers.Network> {
+    return this.provider.getNetwork();
+  }
+
+  /**
+   * Fetches the latest block number.
+   * Retried up to 4 times with exponential backoff before throwing.
+   */
+  @Retryable({ maxAttempts: 4, operationName: 'indexer:getBlockNumber' })
+  private async getBlockNumber(): Promise<number> {
+    return this.provider.getBlockNumber();
+  }
+
+  /**
+   * Queries a range of historical contract events.
+   * Given that queryFilter can time out on a busy node, this gets
+   * 5 attempts with a 1 s base delay.
+   */
+  @Retryable({ maxAttempts: 5, baseDelayMs: 1_000, operationName: 'indexer:queryFilter' })
+  private async queryFilter(
+    contract: ethers.Contract,
+    eventName: string,
+    fromBlock: number,
+    toBlock: number,
+  ): Promise<ethers.EventLog[]> {
+    const results = await contract.queryFilter(eventName, fromBlock, toBlock);
+    return results as ethers.EventLog[];
+  }
+
+  // ─── Historical sync ───────────────────────────────────────────────────────
+
+  async syncHistoricalEvents(): Promise<void> {
+    this.logger.log('Syncing historical events…');
+
     const contract = new ethers.Contract(
       this.registryAddress,
-      abi,
+      CALL_REGISTRY_ABI,
       this.provider,
     );
 
     try {
-      const currentBlock = await this.provider.getBlockNumber();
-      const callCreatedEvents = await contract.queryFilter(
-        'CallCreated',
-        0,
-        currentBlock,
-      );
-      const stakeAddedEvents = await contract.queryFilter(
-        'StakeAdded',
-        0,
-        currentBlock,
-      );
+      const currentBlock = await this.getBlockNumber();
 
-      console.log(
-        `Found ${callCreatedEvents.length} historical CallCreated events and ${stakeAddedEvents.length} StakeAdded events.`,
+      // queryFilter is already wrapped with @Retryable above
+      const [callCreatedEvents, stakeAddedEvents] = await Promise.all([
+        this.queryFilter(contract, 'CallCreated', 0, currentBlock),
+        this.queryFilter(contract, 'StakeAdded', 0, currentBlock),
+      ]);
+
+      this.logger.log(
+        `Found ${callCreatedEvents.length} historical CallCreated events ` +
+          `and ${stakeAddedEvents.length} StakeAdded events`,
       );
 
       for (const event of callCreatedEvents) {
-        if ('args' in event && event.args) {
-          const args = event.args;
+        if (event.args) {
+          const a = event.args;
           await this.handleCallCreated(
-            args[0] as bigint,
-            args[1] as string,
-            args[2] as string,
-            args[3] as bigint,
-            args[4] as bigint,
-            args[5] as bigint,
-            args[6] as string,
-            args[7] as string,
-            args[8] as string,
+            a[0] as bigint, a[1] as string, a[2] as string,
+            a[3] as bigint, a[4] as bigint, a[5] as bigint,
+            a[6] as string, a[7] as string, a[8] as string,
           );
         }
       }
 
       for (const event of stakeAddedEvents) {
-        if ('args' in event && event.args) {
-          const args = event.args;
+        if (event.args) {
+          const a = event.args;
           await this.handleStakeAdded(
-            args[0] as bigint,
-            args[1] as string,
-            args[2] as boolean,
-            args[3] as bigint,
+            a[0] as bigint, a[1] as string, a[2] as boolean, a[3] as bigint,
           );
         }
       }
-    } catch (error) {
-      console.error('Error syncing historical events:', error);
+
+      this.logger.log('Historical sync complete');
+    } catch (err) {
+      if (err instanceof RpcExhaustedError) {
+        this.logger.error(
+          `Historical sync failed after ${err.attempts} RPC attempts: ${err.lastError.message}`,
+        );
+      } else {
+        this.logger.error('Unexpected error during historical sync', (err as Error).message);
+      }
+      // Do not rethrow — a failed historical sync should not prevent the live listener from starting
     }
   }
+
+  // ─── Event handlers ────────────────────────────────────────────────────────
 
   async handleCallCreated(
     callId: bigint,
@@ -113,21 +187,24 @@ export class IndexerService implements OnModuleInit {
     tokenAddress: string,
     pairId: string,
     ipfsCID: string,
-  ) {
+  ): Promise<void> {
     const existing = await this.callsRepository.findOne({
       where: { callOnchainId: callId.toString() },
     });
     if (existing) return;
 
-    console.log(`Processing CallCreated: ${callId} by ${creator}`);
+    this.logger.log(`Processing CallCreated: ${callId} by ${creator}`);
     await this.authService.validateUser(creator);
 
-    let conditionJson: any = {};
+    let conditionJson: Record<string, unknown> = {};
     if (ipfsCID && ipfsCID.length > 0) {
       try {
         conditionJson = await this.fetchIpfsData(ipfsCID);
-      } catch (e) {
-        console.error(`Failed to fetch IPFS data for ${ipfsCID}:`, e);
+      } catch (err) {
+        // IPFS fetch exhausted all retries — store the call anyway with empty metadata
+        this.logger.error(
+          `Failed to fetch IPFS data for ${ipfsCID} after retries: ${(err as Error).message}`,
+        );
       }
     }
 
@@ -142,19 +219,67 @@ export class IndexerService implements OnModuleInit {
       tokenAddress,
       pairId,
       ipfsCid: ipfsCID,
-      conditionJson: conditionJson as Record<string, any>,
+      conditionJson,
       status: 'active',
     });
 
     await this.callsRepository.save(call);
+    this.logger.log(`Saved Call ${callId} to database`);
   }
 
-  async fetchIpfsData(cid: string): Promise<Record<string, any>> {
+  async handleStakeAdded(
+    callId: bigint,
+    staker: string,
+    position: boolean,
+    amount: bigint,
+  ): Promise<void> {
+    this.logger.log(
+      `Processing StakeAdded to Call ${callId}: ` +
+        `${ethers.formatUnits(amount, 18)} on ${position ? 'YES' : 'NO'} by ${staker}`,
+    );
+
+    const call = await this.callsRepository.findOne({
+      where: { callOnchainId: callId.toString() },
+    });
+
+    if (!call) {
+      this.logger.warn(
+        `StakeAdded received for unknown Call ${callId} — skipping`,
+      );
+      return;
+    }
+
+    const amountNum = Number(ethers.formatUnits(amount, 18));
+    if (position) {
+      call.totalStakeYes = Number(call.totalStakeYes) + amountNum;
+    } else {
+      call.totalStakeNo = Number(call.totalStakeNo) + amountNum;
+    }
+
+    await this.callsRepository.save(call);
+  }
+
+  // ─── IPFS fetching ─────────────────────────────────────────────────────────
+
+  /**
+   * Fetches JSON metadata from IPFS, trying multiple gateways in order.
+   *
+   * Each gateway attempt is individually retried with exponential backoff
+   * via withRetry(). If every gateway exhausts its attempts, the last
+   * RpcExhaustedError is re-thrown so the caller can decide how to degrade.
+   *
+   * Gateway priority:
+   *   1. Local proxy (avoids CORS, fastest in dev)
+   *   2. Pinata cloud
+   *   3. ipfs.io
+   *   4. dweb.link
+   */
+  async fetchIpfsData(cid: string): Promise<Record<string, unknown>> {
+    // Stable mock — no network call needed in tests / local dev
     if (cid === 'QmMockCID') {
       return {
         title: 'ETH will flip BTC',
-        thesis:
-          'Ethereum has better fundamentals and yielding properties than Bitcoin.',
+        thesis: 'Ethereum has better fundamentals and yielding properties than Bitcoin.',
         target: '0.06 BTC',
         deadline: '2026-01-01',
       };
@@ -167,92 +292,129 @@ export class IndexerService implements OnModuleInit {
       `https://dweb.link/ipfs/${cid}`,
     ];
 
+    let lastErr: Error = new Error('No gateways configured');
+
     for (const url of gateways) {
       try {
-        const response = await fetch(url);
-        if (response.ok) {
-          return (await response.json()) as Record<string, any>;
-        }
-      } catch (error) {
-        console.error(`Error fetching from ${url}:`, error);
-        continue;
+        // Each gateway gets its own retry budget: 3 attempts, 500 ms base
+        const data = await withRetry(
+          async () => {
+            const response = await fetch(url, {
+              signal: AbortSignal.timeout(6_000),
+            });
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status} from ${url}`);
+            }
+            return (await response.json()) as Record<string, unknown>;
+          },
+          {
+            maxAttempts: 3,
+            baseDelayMs: 500,
+            operationName: `indexer:fetchIpfs:${url.split('/ipfs/')[0]}`,
+          },
+          this.logger,
+        );
+
+        this.logger.log(`IPFS data fetched for ${cid} via ${url}`);
+        return data;
+      } catch (err) {
+        lastErr = err instanceof Error ? err : new Error(String(err));
+        this.logger.warn(
+          `IPFS gateway ${url} exhausted — trying next. Reason: ${lastErr.message}`,
+        );
       }
     }
-    return {} as Record<string, any>;
+
+    // All gateways failed — throw so handleCallCreated can log and store empty metadata
+    throw new RpcExhaustedError(`ipfs:${cid}`, gateways.length * 3, lastErr);
   }
 
-  async handleStakeAdded(
-    callId: bigint,
-    staker: string,
-    position: boolean,
-    amount: bigint,
-  ) {
-    console.log(
-      `Processing StakeAdded to Call ${callId}: ${amount} on ${position ? 'YES' : 'NO'}`,
-    );
-    const call = await this.callsRepository.findOne({
-      where: { callOnchainId: callId.toString() },
-    });
-    if (call) {
-      const amountNum = Number(ethers.formatUnits(amount, 18));
-      if (position) {
-        call.totalStakeYes = Number(call.totalStakeYes) + amountNum;
-      } else {
-        call.totalStakeNo = Number(call.totalStakeNo) + amountNum;
-      }
-      await this.callsRepository.save(call);
-    }
-  }
+  // ─── Live listener with auto-reconnect ────────────────────────────────────
 
-  startListening() {
-    console.log('Starting indexer on ' + this.registryAddress);
-
-    const abi = [
-      'event CallCreated(uint256 indexed callId, address indexed creator, address stakeToken, uint256 stakeAmount, uint256 startTs, uint256 endTs, address tokenAddress, bytes32 pairId, string ipfsCID)',
-      'event StakeAdded(uint256 indexed callId, address indexed staker, bool position, uint256 amount)',
-    ];
+  /**
+   * Attaches ethers.js event listeners for real-time contract events.
+   *
+   * If the provider emits an 'error' event (dropped WebSocket, rate-limit, etc.)
+   * the listener tears itself down and schedules a reconnect with exponential
+   * backoff, up to LISTENER_MAX_RECONNECTS times.
+   */
+  startListening(): void {
+    this.logger.log(`Starting live listener on ${this.registryAddress}`);
 
     const contract = new ethers.Contract(
       this.registryAddress,
-      abi,
+      CALL_REGISTRY_ABI,
       this.provider,
     );
 
     void contract.on(
       'CallCreated',
       (
-        callId: bigint,
-        creator: string,
-        stakeToken: string,
-        stakeAmount: bigint,
-        startTs: bigint,
-        endTs: bigint,
-        tokenAddress: string,
-        pairId: string,
-        ipfsCID: string,
+        callId: bigint, creator: string, stakeToken: string,
+        stakeAmount: bigint, startTs: bigint, endTs: bigint,
+        tokenAddress: string, pairId: string, ipfsCID: string,
       ) => {
         void this.handleCallCreated(
-          callId,
-          creator,
-          stakeToken,
-          stakeAmount,
-          startTs,
-          endTs,
-          tokenAddress,
-          pairId,
-          ipfsCID,
-        ).catch((err) =>
-          console.error('[Indexer] Error handling CallCreated:', err),
+          callId, creator, stakeToken, stakeAmount,
+          startTs, endTs, tokenAddress, pairId, ipfsCID,
+        ).catch((err: Error) =>
+          this.logger.error(`Error handling live CallCreated: ${err.message}`),
         );
       },
     );
+
     void contract.on(
       'StakeAdded',
       (callId: bigint, staker: string, position: boolean, amount: bigint) => {
         void this.handleStakeAdded(callId, staker, position, amount).catch(
-          (err) => console.error('[Indexer] Error handling StakeAdded:', err),
+          (err: Error) =>
+            this.logger.error(`Error handling live StakeAdded: ${err.message}`),
         );
       },
     );
+
+    // Attach a provider-level error handler to detect dropped connections
+    this.provider.on('error', (err: Error) => {
+      this.logger.warn(`Provider error detected: ${err.message}`);
+      void contract.removeAllListeners();
+      this.scheduleReconnect();
+    });
+  }
+
+  /**
+   * Schedules a listener reconnect with exponential backoff.
+   * Gives up after LISTENER_MAX_RECONNECTS consecutive failures.
+   */
+  private scheduleReconnect(): void {
+    if (this.reconnectCount >= LISTENER_MAX_RECONNECTS) {
+      this.logger.error(
+        `Live listener failed to reconnect after ${LISTENER_MAX_RECONNECTS} attempts — giving up. ` +
+          `Restart the service to resume real-time indexing.`,
+      );
+      return;
+    }
+
+    const delay = Math.min(
+      LISTENER_RECONNECT_DELAY_MS * Math.pow(2, this.reconnectCount),
+      300_000, // cap at 5 minutes
+    );
+
+    this.reconnectCount++;
+    this.logger.warn(
+      `Scheduling listener reconnect attempt ${this.reconnectCount}/${LISTENER_MAX_RECONNECTS} in ${delay}ms`,
+    );
+
+    setTimeout(() => {
+      this.logger.log(`Reconnecting live listener (attempt ${this.reconnectCount})…`);
+      try {
+        this.startListening();
+        // Reset counter on successful reconnect
+        this.reconnectCount = 0;
+        this.logger.log('Live listener reconnected successfully');
+      } catch (err) {
+        this.logger.error(`Reconnect attempt failed: ${(err as Error).message}`);
+        this.scheduleReconnect();
+      }
+    }, delay);
   }
 }

--- a/packages/backend/src/migration/1700000000000-InitialSchema.ts
+++ b/packages/backend/src/migration/1700000000000-InitialSchema.ts
@@ -1,0 +1,248 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * InitialSchema1700000000000
+ *
+ * Baseline migration — represents the complete schema at the point
+ * synchronize: true was disabled. Every subsequent schema change gets
+ * its own migration file generated via `npm run typeorm:generate`.
+ *
+ * Tables created:
+ *   calls             — trading call records (core domain)
+ *   users             — registered user accounts
+ *   audit_logs        — immutable admin action log  (#81)
+ *   ip_rules          — firewall whitelist/blacklist (#83)
+ *   blocked_requests  — firewall drop log           (#83)
+ *
+ * CHECK constraints (integrity guardrails):
+ *   calls.total_stake_yes  >= 0
+ *   calls.total_stake_no   >= 0
+ *   calls.end_ts            > calls.start_ts
+ *   audit_logs.http_status BETWEEN 100 AND 599
+ */
+export class InitialSchema1700000000000 implements MigrationInterface {
+  name = 'InitialSchema1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+
+    // ── Postgres enums ────────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE audit_action_type_enum AS ENUM (
+          'ORACLE_PARAMS_UPDATED',
+          'ORACLE_QUORUM_SET',
+          'MARKET_MANUALLY_RESOLVED',
+          'MARKET_DISPUTED',
+          'MARKET_PAUSED',
+          'ADMIN_ACTION'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE audit_status_enum AS ENUM (
+          'SUCCESS',
+          'FAILURE'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE ip_rule_type_enum AS ENUM (
+          'WHITELIST',
+          'BLACKLIST'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE block_reason_enum AS ENUM (
+          'BLACKLISTED_IP',
+          'BOT_FINGERPRINT',
+          'TURNSTILE_FAILED',
+          'RATE_LIMIT_EXCEEDED',
+          'MALFORMED_REQUEST'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE call_status_enum AS ENUM (
+          'active',
+          'resolved',
+          'disputed',
+          'expired',
+          'cancelled'
+        );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    // ── users ─────────────────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "users" (
+        "id"            UUID          NOT NULL DEFAULT gen_random_uuid(),
+        "wallet_address" VARCHAR(256)  NOT NULL,
+        "username"      VARCHAR(128),
+        "avatar_url"    TEXT,
+        "bio"           TEXT,
+        "created_at"    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+        "updated_at"    TIMESTAMPTZ   NOT NULL DEFAULT now(),
+
+        CONSTRAINT "PK_users" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_users_wallet_address" UNIQUE ("wallet_address")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_users_wallet_address" ON "users" ("wallet_address");
+    `);
+
+    // ── calls ─────────────────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "calls" (
+        "id"                UUID            NOT NULL DEFAULT gen_random_uuid(),
+        "call_onchain_id"   VARCHAR(128)    NOT NULL,
+        "creator_wallet"    VARCHAR(256)    NOT NULL,
+        "stake_token"       VARCHAR(256)    NOT NULL,
+        "total_stake_yes"   NUMERIC(36,18)  NOT NULL DEFAULT 0,
+        "total_stake_no"    NUMERIC(36,18)  NOT NULL DEFAULT 0,
+        "start_ts"          TIMESTAMPTZ     NOT NULL,
+        "end_ts"            TIMESTAMPTZ     NOT NULL,
+        "token_address"     VARCHAR(256)    NOT NULL,
+        "pair_id"           VARCHAR(128),
+        "ipfs_cid"          VARCHAR(512),
+        "condition_json"    JSONB,
+        "status"            call_status_enum NOT NULL DEFAULT 'active',
+        "created_at"        TIMESTAMPTZ     NOT NULL DEFAULT now(),
+        "updated_at"        TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+        CONSTRAINT "PK_calls"                      PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_calls_call_onchain_id"      UNIQUE ("call_onchain_id"),
+
+        -- Integrity guardrails: stakes can never go negative
+        CONSTRAINT "CHK_calls_total_stake_yes_non_negative"
+          CHECK ("total_stake_yes" >= 0),
+        CONSTRAINT "CHK_calls_total_stake_no_non_negative"
+          CHECK ("total_stake_no" >= 0),
+
+        -- end must be strictly after start
+        CONSTRAINT "CHK_calls_end_after_start"
+          CHECK ("end_ts" > "start_ts")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_calls_call_onchain_id"  ON "calls" ("call_onchain_id");
+      CREATE INDEX "IDX_calls_creator_wallet"   ON "calls" ("creator_wallet");
+      CREATE INDEX "IDX_calls_status"           ON "calls" ("status");
+      CREATE INDEX "IDX_calls_end_ts"           ON "calls" ("end_ts");
+    `);
+
+    // ── audit_logs ────────────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "audit_logs" (
+        "id"               UUID                   NOT NULL DEFAULT gen_random_uuid(),
+        "timestamp"        TIMESTAMPTZ            NOT NULL DEFAULT now(),
+        "actor_id"         VARCHAR(256)           NOT NULL,
+        "action_type"      audit_action_type_enum NOT NULL,
+        "target_resource"  VARCHAR(512)           NOT NULL,
+        "request_payload"  JSONB,
+        "response_payload" JSONB,
+        "http_status"      INTEGER                NOT NULL,
+        "status"           audit_status_enum      NOT NULL,
+        "note"             TEXT,
+
+        CONSTRAINT "PK_audit_logs" PRIMARY KEY ("id"),
+
+        -- HTTP status codes are defined in the 100–599 range
+        CONSTRAINT "CHK_audit_logs_http_status_range"
+          CHECK ("http_status" BETWEEN 100 AND 599)
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_audit_logs_timestamp"   ON "audit_logs" ("timestamp");
+      CREATE INDEX "IDX_audit_logs_actor_id"    ON "audit_logs" ("actor_id");
+      CREATE INDEX "IDX_audit_logs_action_type" ON "audit_logs" ("action_type");
+    `);
+
+    // ── ip_rules ──────────────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "ip_rules" (
+        "id"          UUID              NOT NULL DEFAULT gen_random_uuid(),
+        "cidr"        VARCHAR(64)       NOT NULL,
+        "type"        ip_rule_type_enum NOT NULL,
+        "reason"      TEXT,
+        "created_by"  VARCHAR(256),
+        "created_at"  TIMESTAMPTZ       NOT NULL DEFAULT now(),
+        "updated_at"  TIMESTAMPTZ       NOT NULL DEFAULT now(),
+
+        CONSTRAINT "PK_ip_rules"   PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_ip_rules_cidr" UNIQUE ("cidr")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_ip_rules_cidr" ON "ip_rules" ("cidr");
+      CREATE INDEX "IDX_ip_rules_type" ON "ip_rules" ("type");
+    `);
+
+    // ── blocked_requests ──────────────────────────────────────────────────────
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "blocked_requests" (
+        "id"          UUID               NOT NULL DEFAULT gen_random_uuid(),
+        "error_code"  VARCHAR(64)        NOT NULL,
+        "ip"          VARCHAR(64)        NOT NULL,
+        "reason"      block_reason_enum  NOT NULL,
+        "method"      VARCHAR(16)        NOT NULL,
+        "path"        VARCHAR(1024)      NOT NULL,
+        "user_agent"  TEXT,
+        "headers"     JSONB,
+        "blocked_at"  TIMESTAMPTZ        NOT NULL DEFAULT now(),
+
+        CONSTRAINT "PK_blocked_requests"          PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_blocked_requests_error_code" UNIQUE ("error_code")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_blocked_requests_error_code" ON "blocked_requests" ("error_code");
+      CREATE INDEX "IDX_blocked_requests_ip"         ON "blocked_requests" ("ip");
+      CREATE INDEX "IDX_blocked_requests_reason"     ON "blocked_requests" ("reason");
+      CREATE INDEX "IDX_blocked_requests_blocked_at" ON "blocked_requests" ("blocked_at");
+    `);
+  }
+
+  // ── down — rolls back the entire baseline cleanly ─────────────────────────
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop tables in reverse dependency order
+    await queryRunner.query(`DROP TABLE IF EXISTS "blocked_requests" CASCADE;`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "ip_rules"          CASCADE;`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "audit_logs"        CASCADE;`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "calls"             CASCADE;`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "users"             CASCADE;`);
+
+    // Drop enums
+    await queryRunner.query(`DROP TYPE IF EXISTS block_reason_enum;`);
+    await queryRunner.query(`DROP TYPE IF EXISTS ip_rule_type_enum;`);
+    await queryRunner.query(`DROP TYPE IF EXISTS audit_status_enum;`);
+    await queryRunner.query(`DROP TYPE IF EXISTS audit_action_type_enum;`);
+    await queryRunner.query(`DROP TYPE IF EXISTS call_status_enum;`);
+  }
+}

--- a/packages/backend/src/oracle/oracle.service.ts
+++ b/packages/backend/src/oracle/oracle.service.ts
@@ -1,10 +1,137 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ethers } from 'ethers';
 import { Keypair } from '@stellar/stellar-sdk';
 
+// ─── Retry configuration ────────────────────────────────────────────────────
+
+interface RetryOptions {
+  maxAttempts?: number;   // total attempts including the first call (default: 4)
+  baseDelayMs?: number;   // initial backoff in ms                   (default: 1000)
+  factor?: number;        // exponential growth factor               (default: 2)
+  maxDelayMs?: number;    // ceiling on any single delay             (default: 30_000)
+  jitter?: number;        // ±fraction of delay to randomise         (default: 0.2)
+  operationName?: string; // label used in log lines
+}
+
+// Thrown when every retry attempt has been exhausted
+export class RpcExhaustedError extends Error {
+  constructor(
+    public readonly operation: string,
+    public readonly attempts: number,
+    public readonly lastError: Error,
+  ) {
+    super(
+      `"${operation}" failed after ${attempts} attempt(s): ${lastError.message}`,
+    );
+    this.name = 'RpcExhaustedError';
+  }
+}
+
+/**
+ * withRetry — exponential-backoff retry engine.
+ *
+ * Backoff schedule (defaults):
+ *   Attempt 1 → immediate
+ *   Attempt 2 → ~1 000 ms
+ *   Attempt 3 → ~2 000 ms
+ *   Attempt 4 → ~4 000 ms  → throws RpcExhaustedError
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+  logger?: Logger,
+): Promise<T> {
+  const {
+    maxAttempts = 4,
+    baseDelayMs = 1_000,
+    factor = 2,
+    maxDelayMs = 30_000,
+    jitter = 0.2,
+    operationName = 'operation',
+  } = options;
+
+  let lastError: Error = new Error('Unknown error');
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+
+      if (attempt === maxAttempts) break;
+
+      const raw = Math.min(baseDelayMs * Math.pow(factor, attempt - 1), maxDelayMs);
+      const delay = Math.max(0, Math.round(raw + raw * jitter * (Math.random() * 2 - 1)));
+
+      logger?.warn(
+        `[${operationName}] attempt ${attempt}/${maxAttempts} failed — ` +
+          `retrying in ${delay}ms. Reason: ${lastError.message}`,
+      );
+
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+
+  throw new RpcExhaustedError(operationName, maxAttempts, lastError);
+}
+
+// ─── Retryable method decorator ─────────────────────────────────────────────
+
+/**
+ * @Retryable(maxAttempts) — decorates any async method with retry + backoff.
+ *
+ * @example
+ * @Retryable(3)
+ * async fetchPrice(token: string): Promise<number> { ... }
+ *
+ * @example
+ * @Retryable({ maxAttempts: 5, baseDelayMs: 500 })
+ * async callSorobanRpc(): Promise<string> { ... }
+ */
+export function Retryable(optionsOrAttempts: number | RetryOptions) {
+  const options: RetryOptions =
+    typeof optionsOrAttempts === 'number'
+      ? { maxAttempts: optionsOrAttempts }
+      : optionsOrAttempts;
+
+  return function (
+    target: object,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ): PropertyDescriptor {
+    const original = descriptor.value as (...args: unknown[]) => Promise<unknown>;
+    const className = target.constructor?.name ?? 'Unknown';
+    const operationName = options.operationName ?? `${className}.${propertyKey}`;
+
+    descriptor.value = async function (...args: unknown[]) {
+      // Use the instance logger if available (NestJS services have this.logger)
+      const logger: Logger | undefined = (this as { logger?: Logger }).logger;
+      return withRetry(() => original.apply(this, args), { ...options, operationName }, logger);
+    };
+
+    Object.defineProperty(descriptor.value, 'name', { value: propertyKey });
+    return descriptor;
+  };
+}
+
+// ─── DexScreener response shape ─────────────────────────────────────────────
+
+interface DexScreenerResponse {
+  pairs: Array<{
+    priceUsd: string;
+    baseToken: { symbol: string };
+    volume: { h24: number };
+    liquidity: { usd: number };
+  }>;
+}
+
+// ─── Service ────────────────────────────────────────────────────────────────
+
 @Injectable()
 export class OracleService {
+  private readonly logger = new Logger(OracleService.name);
+
   private signer: ethers.Wallet;
   private stellarKeypair: Keypair;
 
@@ -14,7 +141,6 @@ export class OracleService {
       this.signer = new ethers.Wallet(privateKey);
     }
 
-    // Initialize Stellar keypair for ed25519 signing
     const stellarSecretKey = this.configService.get<string>(
       'STELLAR_ORACLE_SECRET_KEY',
     );
@@ -23,8 +149,10 @@ export class OracleService {
     }
   }
 
+  // ─── Public key helpers ───────────────────────────────────────────────────
+
   /**
-   * Get the Stellar public key for contract authorization
+   * Get the Stellar public key for contract authorization.
    */
   getStellarPublicKey(): string {
     if (!this.stellarKeypair) {
@@ -33,20 +161,85 @@ export class OracleService {
     return this.stellarKeypair.publicKey();
   }
 
+  // ─── Price fetching ───────────────────────────────────────────────────────
+
+  /**
+   * Fetches the USD price for a token via the DexScreener API.
+   *
+   * Retried automatically with exponential backoff:
+   *   attempt 1 → immediate
+   *   attempt 2 → ~1 s
+   *   attempt 3 → ~2 s
+   *   attempt 4 → ~4 s → throws RpcExhaustedError
+   *
+   * Logs a warning on each failed attempt and only throws after all
+   * attempts are exhausted.
+   */
+  @Retryable({
+    maxAttempts: 4,
+    baseDelayMs: 1_000,
+    operationName: 'oracle:fetchPrice',
+  })
   async fetchPrice(tokenAddress: string): Promise<number> {
-    // Placeholder for DexScreener API call
-    console.log(`Fetching price for ${tokenAddress}`);
-    // const response = await axios.get(`https://api.dexscreener.com/latest/dex/tokens/${tokenAddress}`);
-    // return response.data.pairs[0].priceUsd;
-    return Promise.resolve(1000); // Mock price
+    this.logger.log(`Fetching price for ${tokenAddress}`);
+
+    const url = `https://api.dexscreener.com/latest/dex/tokens/${tokenAddress}`;
+
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(8_000), // 8 s hard timeout per attempt
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `DexScreener responded ${response.status} ${response.statusText} for ${tokenAddress}`,
+      );
+    }
+
+    const data = (await response.json()) as DexScreenerResponse;
+
+    const pair = data?.pairs?.[0];
+    if (!pair?.priceUsd) {
+      throw new Error(`No price data returned by DexScreener for ${tokenAddress}`);
+    }
+
+    const price = parseFloat(pair.priceUsd);
+    this.logger.log(
+      `Price fetched for ${tokenAddress}: $${price} ` +
+        `(${pair.baseToken.symbol}, 24h vol: $${pair.volume.h24})`,
+    );
+
+    return price;
   }
+
+  /**
+   * Fetch price with a graceful fallback — returns null instead of throwing
+   * when all retry attempts are exhausted. Use this when a missing price should
+   * degrade gracefully rather than crash the caller.
+   */
+  async fetchPriceSafe(tokenAddress: string): Promise<number | null> {
+    try {
+      return await this.fetchPrice(tokenAddress);
+    } catch (err) {
+      if (err instanceof RpcExhaustedError) {
+        this.logger.error(
+          `oracle:fetchPrice exhausted after ${err.attempts} attempts for ` +
+            `${tokenAddress} — ${err.lastError.message}`,
+        );
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  // ─── EVM (EIP-712) signing ────────────────────────────────────────────────
 
   async signOutcome(
     callId: number,
     outcome: boolean,
     finalPrice: number,
     timestamp: number,
-  ) {
+  ): Promise<string> {
     if (!this.signer) throw new Error('Oracle signer not configured');
 
     const domain = {
@@ -67,30 +260,23 @@ export class OracleService {
       ],
     };
 
-    const value = {
-      callId,
-      outcome,
-      finalPrice,
-      timestamp,
-    };
+    const value = { callId, outcome, finalPrice, timestamp };
 
     return this.signer.signTypedData(domain, types, value);
   }
 
+  // ─── Stellar (ed25519) signing ────────────────────────────────────────────
+
   /**
-   * Sign outcome with ed25519 for Stellar/Soroban verification
+   * Sign outcome with ed25519 for Stellar/Soroban verification.
    *
    * Message format: BackIt:Outcome:{callId}:{outcome}:{finalPrice}:{timestamp}
-   * - callId: The unique identifier for the call
-   * - outcome: 'true' or 'false' (as string)
-   * - finalPrice: The final price as a number
-   * - timestamp: Unix timestamp in seconds
+   *   - callId:     unique identifier for the call
+   *   - outcome:    'true' or 'false' (as string)
+   *   - finalPrice: the final price as a number
+   *   - timestamp:  unix timestamp in seconds
    *
-   * @param callId - Unique call identifier
-   * @param outcome - Whether the outcome was successful
-   * @param finalPrice - Final price value
-   * @param timestamp - Unix timestamp when the outcome was determined
-   * @returns Buffer containing 64-byte ed25519 signature (compatible with BytesN<64>)
+   * @returns 64-byte Buffer (compatible with Soroban BytesN<64>)
    */
   signStellarOutcome(
     callId: number,
@@ -102,27 +288,23 @@ export class OracleService {
       throw new Error('Stellar keypair not configured');
     }
 
-    // Construct canonical message format
     // Must match exactly what the Soroban contract expects
     const message = `BackIt:Outcome:${callId}:${outcome}:${finalPrice}:${timestamp}`;
     const messageBuffer = Buffer.from(message, 'utf-8');
 
-    // Sign with ed25519
-    const signature = this.stellarKeypair.sign(messageBuffer);
-
-    return signature;
+    return this.stellarKeypair.sign(messageBuffer);
   }
 
   /**
-   * Sign outcome based on chain type
-   * Automatically detects whether to use EIP-712 (EVM) or ed25519 (Stellar) signing
+   * Sign outcome based on chain type.
+   * Automatically selects EIP-712 (EVM/Base) or ed25519 (Stellar) signing.
    *
-   * @param chain - The blockchain network ('base' or 'stellar')
-   * @param callId - Unique call identifier
-   * @param outcome - Whether the outcome was successful
-   * @param finalPrice - Final price value
-   * @param timestamp - Unix timestamp when the outcome was determined
-   * @returns Signature string (hex for EVM, base64 for Stellar)
+   * @param chain       - 'base' or 'stellar'
+   * @param callId      - unique call identifier
+   * @param outcome     - whether the outcome was successful
+   * @param finalPrice  - final price value
+   * @param timestamp   - unix timestamp when the outcome was determined
+   * @returns hex string (EVM) or base64 string (Stellar)
    */
   async signOutcomeForChain(
     chain: 'base' | 'stellar',
@@ -132,17 +314,10 @@ export class OracleService {
     timestamp: number,
   ): Promise<string> {
     if (chain === 'stellar') {
-      const signature = this.signStellarOutcome(
-        callId,
-        outcome,
-        finalPrice,
-        timestamp,
-      );
-      // Convert to base64 for storage/transmission
+      const signature = this.signStellarOutcome(callId, outcome, finalPrice, timestamp);
       return signature.toString('base64');
-    } else {
-      // Use EIP-712 signing for EVM chains (Base)
-      return this.signOutcome(callId, outcome, finalPrice, timestamp);
     }
+
+    return this.signOutcome(callId, outcome, finalPrice, timestamp);
   }
 }


### PR DESCRIPTION
feat(backend): add RPC exponential backoff retry and production-ready DB migration pipeline (#45 #46)

- Introduce withRetry() engine and @Retryable() decorator with exponential
  backoff (1s, 2s, 4s) and ±20% jitter. Add RpcExhaustedError carrying
  operation name, attempt count, and last error for structured logging.

- Wrap oracle fetchPrice() with @Retryable({ maxAttempts: 4 }) against
  DexScreener API. Add fetchPriceSafe() for graceful null fallback.
  Replace all console.log with Logger.

- Wrap indexer getNetwork(), getBlockNumber(), queryFilter() in dedicated
  @Retryable() private methods. Give each IPFS gateway its own withRetry()
  budget (3 attempts, 500ms base) with fallthrough to next gateway on
  exhaustion. Attach provider.on('error') live listener with auto-reconnect
  using exponential backoff (10s → 5min cap, max 10 attempts).

- Add src/data-source.ts as single DataSource config for both TypeORM CLI
  and AppModule. synchronize hardcoded to false unconditionally.

- Add baseline migration 1700000000000-InitialSchema creating tables users,
  calls, audit_logs, ip_rules, blocked_requests with all enums, indexes,
  and unique constraints. down() drops everything in reverse order.

- Add DB-level CHECK constraints: calls.total_stake_yes >= 0,
  calls.total_stake_no >= 0, calls.end_ts > calls.start_ts,
  audit_logs.http_status BETWEEN 100 AND 599.

- Update AppModule to spread dataSourceOptions from data-source.ts into
  TypeOrmModule.forRoot(), eliminating config drift between CLI and app.

- Add typeorm:run, typeorm:revert, typeorm:show, typeorm:generate,
  typeorm:create, and db:reset scripts to package.json.

Closes #45
Closes #46