### PR TITLE
feat(frontend): add global error boundary fallback UI

### DIFF
--- a/packages/frontend/app/error.tsx
+++ b/packages/frontend/app/error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+type AppErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AppError({ error, reset }: AppErrorProps) {
+  useEffect(() => {
+    console.error("Application error boundary caught an error:", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-6">
+      <div className="w-full max-w-xl rounded-2xl border border-border bg-card p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-bold tracking-tight">Something went wrong</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          We&apos;re sorry, an unexpected error occurred. Please try again or
+          return to the home page.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
+          >
+            Try Again
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+          >
+            Return Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/app/global-error.tsx
+++ b/packages/frontend/app/global-error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error("Global error boundary caught an error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background px-6">
+        <main className="mx-auto flex min-h-screen w-full max-w-xl items-center justify-center">
+          <div className="w-full rounded-2xl border border-border bg-card p-8 text-center shadow-sm">
+            <h1 className="text-2xl font-bold tracking-tight">
+              We hit an unexpected issue
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Sorry about that. You can try the action again, or return home.
+            </p>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
+              >
+                Try Again
+              </button>
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+              >
+                Return Home
+              </Link>
+            </div>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
Implements issue #53 by adding a global error boundary fallback for the Next.js App Router frontend so runtime crashes no longer result in a blank white screen.

## What Changed
- Added root route error boundary: `packages/frontend/app/error.tsx`
- Added global layout-level error boundary: `packages/frontend/app/global-error.tsx`
- Fallback UI now shows:
  - Generic apology message
  - `Try Again` action (`reset()`)
  - `Return Home` action (`/`)
- Caught errors are logged with `console.error(...)` for debugging/monitoring hooks.
- No stack traces or raw internals are exposed to users in the UI.

## Acceptance Criteria Mapping
- [x] Top-level `ErrorBoundary` implemented using Next.js `error.tsx` conventions
- [x] User-friendly fallback UI with retry/home action
- [x] Error is logged safely without exposing internals to end users

## Testing
- Manually verified by temporarily throwing in `app/feed/page.tsx` and visiting `/feed`
- Confirmed fallback UI renders instead of blank screen
- Confirmed `Try Again` and `Return Home` behavior
- Confirmed error appears in browser console logs
- Lint check passed for new files:
  - `npx eslint app/error.tsx app/global-error.tsx`

## Related
- Closes #53 
