### PR TITLE
feat(frontend): add persistent web3 transaction toast lifecycle

### DIFF
--- a/packages/frontend/components/GlobalState.tsx
+++ b/packages/frontend/components/GlobalState.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { useWriteContract, usePublicClient, useAccount } from 'wagmi';
-import { parseEther, stringToHex } from 'viem';
+import { useWriteContract, usePublicClient, useAccount, useChainId } from 'wagmi';
+import { parseEther, stringToHex, type Hash } from 'viem';
 import { CallRegistryABI, ERC20ABI } from '../lib/abis';
 import { useChain } from './ChainProvider';
 import { useStellarWallet } from './StellarWalletProvider';
+import {
+  showTxConfirmedToast,
+  showTxFailedToast,
+  showTxSubmittedToast,
+} from './tx-toast';
 
 export interface Call {
   id: string; // callOnchainId
@@ -65,6 +70,22 @@ const buildApiUrl = (path: string): string => {
 const isNetworkError = (error: unknown): boolean =>
   error instanceof TypeError && (error as Error).message === "Failed to fetch";
 
+const isUserRejectedError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return (
+    message.includes("user rejected") ||
+    message.includes("user denied") ||
+    message.includes("denied transaction signature") ||
+    message.includes("rejected the request") ||
+    message.includes("cancelled")
+  );
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return "Something went wrong while processing this transaction.";
+};
+
 export function GlobalStateProvider({ children }: { children: React.ReactNode }) {
   const [calls, setCalls] = useState<Call[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -72,6 +93,7 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
 
   const { writeContractAsync } = useWriteContract();
   const publicClient = usePublicClient();
+  const chainId = useChainId();
   const { address: evmAddress, isConnected: isEvmConnected } = useAccount();
 
   const { selectedChain } = useChain();
@@ -172,6 +194,52 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
     fetchCalls();
   }, []);
 
+  const trackEvmTransaction = async (params: {
+    submittedTitle: string;
+    confirmedTitle: string;
+    failedTitle: string;
+    write: () => Promise<Hash>;
+  }): Promise<Hash> => {
+    let txHash: Hash | undefined;
+    try {
+      if (!publicClient) {
+        throw new Error("Unable to access chain client. Please reconnect wallet.");
+      }
+
+      txHash = await params.write();
+      showTxSubmittedToast({
+        title: params.submittedTitle,
+        description: "Waiting for onchain confirmation.",
+        hash: txHash,
+        chainId,
+      });
+
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      if (receipt.status !== "success") {
+        throw new Error("Transaction was mined but reverted.");
+      }
+
+      showTxConfirmedToast({
+        title: params.confirmedTitle,
+        description: "Transaction confirmed onchain.",
+        hash: txHash,
+        chainId,
+      });
+
+      return txHash;
+    } catch (error) {
+      showTxFailedToast({
+        title: isUserRejectedError(error) ? "Tx Rejected" : params.failedTitle,
+        description: isUserRejectedError(error)
+          ? "You rejected this transaction in your wallet."
+          : getErrorMessage(error),
+        hash: txHash,
+        chainId,
+      });
+      throw error;
+    }
+  };
+
   const createCall = async (newCallData: Omit<Call, 'id' | 'creator' | 'status' | 'createdAt' | 'backers' | 'comments' | 'volume' | 'totalStakeYes' | 'totalStakeNo' | 'stakeToken' | 'endTs' | 'conditionJson'>) => {
     if (!currentUser) {
       alert("Please connect wallet first");
@@ -205,30 +273,40 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       const { cid } = await ipfsRes.json();
 
       // 2. Approve Token
-      const approveTx = await writeContractAsync({
-        address: tokenAddress,
-        abi: ERC20ABI,
-        functionName: "approve",
-        args: [registryAddress, stakeAmount],
+      await trackEvmTransaction({
+        submittedTitle: "Tx Submitted: Token approval",
+        confirmedTitle: "Tx Confirmed: Token approval",
+        failedTitle: "Tx Failed: Token approval",
+        write: () =>
+          writeContractAsync({
+            address: tokenAddress,
+            abi: ERC20ABI,
+            functionName: "approve",
+            args: [registryAddress, stakeAmount],
+          }),
       });
-      await publicClient?.waitForTransactionReceipt({ hash: approveTx });
 
       // 3. Create Call
       const deadlineTimestamp = Math.floor(new Date(newCallData.deadline).getTime() / 1000);
-      const createTx = await writeContractAsync({
-        address: registryAddress,
-        abi: CallRegistryABI,
-        functionName: "createCall",
-        args: [
-          tokenAddress,
-          stakeAmount,
-          BigInt(deadlineTimestamp),
-          tokenAddress,
-          stringToHex(newCallData.asset, { size: 32 }),
-          cid,
-        ],
+      await trackEvmTransaction({
+        submittedTitle: "Tx Submitted: Create call",
+        confirmedTitle: "Tx Confirmed: Create call",
+        failedTitle: "Tx Failed: Create call",
+        write: () =>
+          writeContractAsync({
+            address: registryAddress,
+            abi: CallRegistryABI,
+            functionName: "createCall",
+            args: [
+              tokenAddress,
+              stakeAmount,
+              BigInt(deadlineTimestamp),
+              tokenAddress,
+              stringToHex(newCallData.asset, { size: 32 }),
+              cid,
+            ],
+          }),
       });
-      await publicClient?.waitForTransactionReceipt({ hash: createTx });
 
       // Optimistic Update
       const newCall: Call = {
@@ -255,7 +333,6 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       setTimeout(fetchCalls, 8000);
     } catch (error) {
       console.error("Failed to create call:", error);
-      alert("Failed to create call. See console for details.");
     } finally {
       setIsLoading(false);
     }
@@ -273,22 +350,32 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       const tokenAddress = process.env.NEXT_PUBLIC_MOCK_TOKEN_ADDRESS as `0x${string}`;
       const registryAddress = process.env.NEXT_PUBLIC_CALL_REGISTRY_ADDRESS as `0x${string}`;
 
-      const approveTx = await writeContractAsync({
-        address: tokenAddress,
-        abi: ERC20ABI,
-        functionName: "approve",
-        args: [registryAddress, stakeAmount],
+      await trackEvmTransaction({
+        submittedTitle: "Tx Submitted: Token approval",
+        confirmedTitle: "Tx Confirmed: Token approval",
+        failedTitle: "Tx Failed: Token approval",
+        write: () =>
+          writeContractAsync({
+            address: tokenAddress,
+            abi: ERC20ABI,
+            functionName: "approve",
+            args: [registryAddress, stakeAmount],
+          }),
       });
-      await publicClient?.waitForTransactionReceipt({ hash: approveTx });
 
       const position = type === "back";
-      const stakeTx = await writeContractAsync({
-        address: registryAddress,
-        abi: CallRegistryABI,
-        functionName: "stakeOnCall",
-        args: [BigInt(callId), stakeAmount, position],
+      await trackEvmTransaction({
+        submittedTitle: "Tx Submitted: Stake on call",
+        confirmedTitle: "Tx Confirmed: Stake on call",
+        failedTitle: "Tx Failed: Stake on call",
+        write: () =>
+          writeContractAsync({
+            address: registryAddress,
+            abi: CallRegistryABI,
+            functionName: "stakeOnCall",
+            args: [BigInt(callId), stakeAmount, position],
+          }),
       });
-      await publicClient?.waitForTransactionReceipt({ hash: stakeTx });
 
       setCalls((prev) =>
         prev.map((call) => {
@@ -306,7 +393,6 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       );
     } catch (error) {
       console.error("Failed to stake:", error);
-      alert("Failed to stake. See console for details.");
     } finally {
       setIsLoading(false);
     }

--- a/packages/frontend/components/Providers.tsx
+++ b/packages/frontend/components/Providers.tsx
@@ -14,6 +14,7 @@ import {
 import type { Chain } from "viem";
 import { coinbaseWallet, injected } from "wagmi/connectors";
 import { ReactNode, useState } from "react";
+import { Toaster } from "sonner";
 
 import { GlobalStateProvider } from "./GlobalState";
 import { NetworkGuard } from "./NetworkGuard";
@@ -74,6 +75,7 @@ export function Providers(props: {
               <StellarWalletProvider>
                 {/* Global application state */}
                 <GlobalStateProvider>{props.children}</GlobalStateProvider>
+                <Toaster position="top-right" closeButton />
               </StellarWalletProvider>
             </NetworkGuard>
           </OnchainKitProvider>

--- a/packages/frontend/components/tx-toast.tsx
+++ b/packages/frontend/components/tx-toast.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, CheckCircle2, Clock3, ExternalLink } from "lucide-react";
+import { toast } from "sonner";
+import type { Hash } from "viem";
+
+type TxToastVariant = "submitted" | "confirmed" | "failed";
+
+interface TxToastOptions {
+  title: string;
+  description: string;
+  hash?: Hash;
+  chainId?: number;
+}
+
+const TX_TOAST_DURATION_MS = 12_000;
+
+const getExplorerTxUrl = (hash: Hash, chainId?: number): string | undefined => {
+  if (!chainId) return undefined;
+
+  const explorerByChainId: Record<number, string> = {
+    8453: "https://basescan.org/tx/",
+    84532: "https://sepolia.basescan.org/tx/",
+  };
+
+  const baseUrl = explorerByChainId[chainId];
+  return baseUrl ? `${baseUrl}${hash}` : undefined;
+};
+
+const TxToastCard = ({
+  variant,
+  title,
+  description,
+  explorerUrl,
+}: {
+  variant: TxToastVariant;
+  title: string;
+  description: string;
+  explorerUrl?: string;
+}) => {
+  const iconByVariant = {
+    submitted: <Clock3 className="h-5 w-5 text-amber-500" />,
+    confirmed: <CheckCircle2 className="h-5 w-5 text-emerald-500" />,
+    failed: <AlertCircle className="h-5 w-5 text-red-500" />,
+  };
+
+  return (
+    <div className="w-[340px] rounded-lg border border-zinc-700 bg-zinc-900 p-3 text-white shadow-xl">
+      <div className="flex items-start gap-2">
+        {iconByVariant[variant]}
+        <div className="flex-1">
+          <p className="text-sm font-semibold">{title}</p>
+          <p className="mt-1 text-xs text-zinc-300">{description}</p>
+          {explorerUrl ? (
+            <Link
+              href={explorerUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-sky-300 hover:text-sky-200"
+            >
+              View on explorer
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const showTxToast = (variant: TxToastVariant, options: TxToastOptions) => {
+  const explorerUrl = options.hash
+    ? getExplorerTxUrl(options.hash, options.chainId)
+    : undefined;
+
+  toast.custom(
+    () => (
+      <TxToastCard
+        variant={variant}
+        title={options.title}
+        description={options.description}
+        explorerUrl={explorerUrl}
+      />
+    ),
+    {
+      duration: TX_TOAST_DURATION_MS,
+    },
+  );
+};
+
+export const showTxSubmittedToast = (options: TxToastOptions) => {
+  showTxToast("submitted", options);
+};
+
+export const showTxConfirmedToast = (options: TxToastOptions) => {
+  showTxToast("confirmed", options);
+};
+
+export const showTxFailedToast = (options: TxToastOptions) => {
+  showTxToast("failed", options);
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,6 +26,7 @@
     "next": "16.0.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "lightweight-charts": "^5.0.3",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -6042,6 +6045,12 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
@@ -11972,7 +11981,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11999,7 +12008,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12014,13 +12023,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12035,7 +12044,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14525,6 +14534,11 @@ snapshots:
   sonic-boom@2.8.0:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sonner@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   sort-keys-length@1.0.1:
     dependencies:


### PR DESCRIPTION

Closes #56

## Overview

Implements a persistent transaction toast lifecycle for EVM contract writes so users get immediate and continuous feedback while transactions are pending and after they confirm/fail.  
Toasts are mounted globally so they persist across route changes.

## Changes

### Toast System

- **[ADD]** [tx-toast.tsx](/c:/Users/pd307/Pictures/opensource/back-it-onchain/packages/frontend/components/tx-toast.tsx)
  - Added custom toast UI + helpers using `sonner`:
    - `Tx Submitted`
    - `Tx Confirmed` (with explorer link for Base/Base Sepolia)
    - `Tx Rejected/Failed`
  - Added wallet rejection detection copy (`Tx Rejected`) and generic failure handling.

### Global Provider

- **[MODIFY]** [Providers.tsx](/c:/Users/pd307/Pictures/opensource/back-it-onchain/packages/frontend/components/Providers.tsx)
  - Mounted global `<Toaster />` at provider/root level (`top-right`, close button enabled).
  - Ensures notifications persist across route navigation.

### Contract Write Callback Integration

- **[MODIFY]** [GlobalState.tsx](/c:/Users/pd307/Pictures/opensource/back-it-onchain/packages/frontend/components/GlobalState.tsx)
  - Added a reusable `trackEvmTransaction(...)` wrapper around write+receipt flow.
  - Wired to existing OnchainKit/Wagmi-backed writes:
    - `approve` (create flow)
    - `createCall`
    - `approve` (stake flow)
    - `stakeOnCall`
  - Replaced blocking `alert` error UX for these EVM transaction failures with toast feedback.
  - Includes receipt status validation and chain-aware explorer linking.

### Dependencies

- **[MODIFY]** [package.json](/c:/Users/pd307/Pictures/opensource/back-it-onchain/packages/frontend/package.json)
  - Added `sonner`.
- **[MODIFY]** [pnpm-lock.yaml](/c:/Users/pd307/Pictures/opensource/back-it-onchain/pnpm-lock.yaml)
  - Updated lockfile entries for `sonner`.

## How to Run

From repo root:

```bash
pnpm install
pnpm --filter frontend dev
```

## Verification Results

| Requirement | Status |
|---|---|
| Integrate toast library | Done (`sonner`) |
| Custom toasts: Submitted / Confirmed / Rejected-Failed | Done |
| Confirmed toast includes explorer link | Done (Base + Base Sepolia) |
| Hook to OnchainKit contract write callbacks | Done (existing EVM write paths) |
| Toast persists across route changes | Done (global provider mount) |

<img width="1105" height="679" alt="image" src="https://github.com/user-attachments/assets/b60e72d9-dff5-4a7c-aa99-ab7edee50433" />
