### PR TITLE
feat: implement social graph follow/unfollow endpoints

### DIFF
--- a/packages/backend/src/users/dto/follow.dto.ts
+++ b/packages/backend/src/users/dto/follow.dto.ts
@@ -1,0 +1,12 @@
+export class FollowResponseDto {
+  id: string;
+  address: string;
+  username?: string;
+  avatar?: string;
+  followedAt: Date;
+}
+
+export class FollowStatsDto {
+  followersCount: number;
+  followingCount: number;
+}

--- a/packages/backend/src/users/entities/follow.entity.ts
+++ b/packages/backend/src/users/entities/follow.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Column,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('follows')
+export class Follow {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  followerId: string;
+
+  @Column()
+  followingId: string;
+
+  @ManyToOne(() => User, (user) => user.following, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'followerId' })
+  follower: User;
+
+  @ManyToOne(() => User, (user) => user.followers, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'followingId' })
+  following: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/users/follow.controller.ts
+++ b/packages/backend/src/users/follow.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { FollowService } from './follow.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('users')
+export class FollowController {
+  constructor(private readonly followService: FollowService) {}
+
+  @Post(':address/follow')
+  @UseGuards(JwtAuthGuard)
+  async followUser(
+    @Param('address') targetAddress: string,
+    @Request() req: any,
+  ) {
+    return this.followService.followUser(req.user.address, targetAddress);
+  }
+
+  @Post(':address/unfollow')
+  @UseGuards(JwtAuthGuard)
+  async unfollowUser(
+    @Param('address') targetAddress: string,
+    @Request() req: any,
+  ) {
+    return this.followService.unfollowUser(req.user.address, targetAddress);
+  }
+
+  @Get(':address/followers')
+  async getFollowers(
+    @Param('address') address: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+  ) {
+    return this.followService.getFollowers(address, +page, +limit);
+  }
+
+  @Get(':address/following')
+  async getFollowing(
+    @Param('address') address: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+  ) {
+    return this.followService.getFollowing(address, +page, +limit);
+  }
+
+  @Get(':address/follow-stats')
+  async getFollowStats(@Param('address') address: string) {
+    return this.followService.getFollowStats(address);
+  }
+
+  @Get(':address/is-following')
+  @UseGuards(JwtAuthGuard)
+  async isFollowing(
+    @Param('address') targetAddress: string,
+    @Request() req: any,
+  ) {
+    return this.followService.isFollowing(req.user.address, targetAddress);
+  }
+}

--- a/packages/backend/src/users/follow.service.ts
+++ b/packages/backend/src/users/follow.service.ts
@@ -1,0 +1,214 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Follow } from './entities/follow.entity';
+import { User } from './entities/user.entity';
+import { FollowResponseDto, FollowStatsDto } from './dto/follow.dto';
+
+@Injectable()
+export class FollowService {
+  constructor(
+    @InjectRepository(Follow)
+    private readonly followRepository: Repository<Follow>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async followUser(
+    currentUserAddress: string,
+    targetAddress: string,
+  ): Promise<{ message: string }> {
+    if (currentUserAddress.toLowerCase() === targetAddress.toLowerCase()) {
+      throw new BadRequestException('You cannot follow yourself');
+    }
+
+    const [currentUser, targetUser] = await Promise.all([
+      this.userRepository.findOne({
+        where: { address: currentUserAddress.toLowerCase() },
+      }),
+      this.userRepository.findOne({
+        where: { address: targetAddress.toLowerCase() },
+      }),
+    ]);
+
+    if (!currentUser) {
+      throw new NotFoundException('Current user not found');
+    }
+    if (!targetUser) {
+      throw new NotFoundException('Target user not found');
+    }
+
+    const existingFollow = await this.followRepository.findOne({
+      where: {
+        followerId: currentUser.id,
+        followingId: targetUser.id,
+      },
+    });
+
+    if (existingFollow) {
+      throw new ConflictException('You are already following this user');
+    }
+
+    const follow = this.followRepository.create({
+      followerId: currentUser.id,
+      followingId: targetUser.id,
+    });
+
+    await this.followRepository.save(follow);
+
+    return { message: `You are now following ${targetAddress}` };
+  }
+
+  async unfollowUser(
+    currentUserAddress: string,
+    targetAddress: string,
+  ): Promise<{ message: string }> {
+    if (currentUserAddress.toLowerCase() === targetAddress.toLowerCase()) {
+      throw new BadRequestException('You cannot unfollow yourself');
+    }
+
+    const [currentUser, targetUser] = await Promise.all([
+      this.userRepository.findOne({
+        where: { address: currentUserAddress.toLowerCase() },
+      }),
+      this.userRepository.findOne({
+        where: { address: targetAddress.toLowerCase() },
+      }),
+    ]);
+
+    if (!currentUser) {
+      throw new NotFoundException('Current user not found');
+    }
+    if (!targetUser) {
+      throw new NotFoundException('Target user not found');
+    }
+
+    const existingFollow = await this.followRepository.findOne({
+      where: {
+        followerId: currentUser.id,
+        followingId: targetUser.id,
+      },
+    });
+
+    if (!existingFollow) {
+      throw new BadRequestException('You are not following this user');
+    }
+
+    await this.followRepository.remove(existingFollow);
+
+    return { message: `You have unfollowed ${targetAddress}` };
+  }
+
+  async getFollowers(
+    address: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{ data: FollowResponseDto[]; total: number }> {
+    const user = await this.userRepository.findOne({
+      where: { address: address.toLowerCase() },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const [follows, total] = await this.followRepository.findAndCount({
+      where: { followingId: user.id },
+      relations: ['follower'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const data: FollowResponseDto[] = follows.map((f) => ({
+      id: f.follower.id,
+      address: f.follower.address,
+      username: f.follower.username,
+      avatar: f.follower.avatar,
+      followedAt: f.createdAt,
+    }));
+
+    return { data, total };
+  }
+
+  async getFollowing(
+    address: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{ data: FollowResponseDto[]; total: number }> {
+    const user = await this.userRepository.findOne({
+      where: { address: address.toLowerCase() },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const [follows, total] = await this.followRepository.findAndCount({
+      where: { followerId: user.id },
+      relations: ['following'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const data: FollowResponseDto[] = follows.map((f) => ({
+      id: f.following.id,
+      address: f.following.address,
+      username: f.following.username,
+      avatar: f.following.avatar,
+      followedAt: f.createdAt,
+    }));
+
+    return { data, total };
+  }
+
+  async getFollowStats(address: string): Promise<FollowStatsDto> {
+    const user = await this.userRepository.findOne({
+      where: { address: address.toLowerCase() },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const [followersCount, followingCount] = await Promise.all([
+      this.followRepository.count({ where: { followingId: user.id } }),
+      this.followRepository.count({ where: { followerId: user.id } }),
+    ]);
+
+    return { followersCount, followingCount };
+  }
+
+  async isFollowing(
+    currentUserAddress: string,
+    targetAddress: string,
+  ): Promise<{ isFollowing: boolean }> {
+    const [currentUser, targetUser] = await Promise.all([
+      this.userRepository.findOne({
+        where: { address: currentUserAddress.toLowerCase() },
+      }),
+      this.userRepository.findOne({
+        where: { address: targetAddress.toLowerCase() },
+      }),
+    ]);
+
+    if (!currentUser || !targetUser) {
+      return { isFollowing: false };
+    }
+
+    const follow = await this.followRepository.findOne({
+      where: {
+        followerId: currentUser.id,
+        followingId: targetUser.id,
+      },
+    });
+
+    return { isFollowing: !!follow };
+  }
+}


### PR DESCRIPTION
 Description:
  Adds follow/unfollow functionality to the users module.

  - POST /users/:address/follow and POST /users/:address/unfollow endpoints (JWT protected)
  - GET /users/:address/followers and /following with pagination
  - GET /users/:address/follow-stats and /is-following helper endpoints
  - Follow join entity storing followerId, followingId, and createdAt timestamp
  - Guards against self-follow, duplicate follows, and non-existent users
  
  closes #41 