### PR TITLE
feat: implement reporting and auto-hiding of inappropriate calls

### DIFF
--- a/packages/backend/src/calls/call.entity.ts
+++ b/packages/backend/src/calls/call.entity.ts
@@ -14,6 +14,12 @@ export class Call {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ nullable: true })
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
   @Column({ type: 'bigint', nullable: true })
   callOnchainId: string;
 
@@ -68,6 +74,12 @@ export class Call {
 
   @Column({ default: 'base' })
   chain: 'base' | 'stellar';
+
+  @Column({ default: false })
+  isHidden: boolean;
+
+  @Column({ default: 0 })
+  reportCount: number;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/packages/backend/src/calls/calls.controller.ts
+++ b/packages/backend/src/calls/calls.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, Request, HttpException, HttpStatus } from '@nestjs/common';
 import { CallsService } from './calls.service';
 import { Call } from './call.entity';
 
@@ -22,7 +22,11 @@ export class CallsController {
   }
 
   @Post(':id/report')
-  report(@Param('id') id: string, @Body('reason') reason: string) {
+  report(@Param('id') id: string, @Body('reason') reason: string, @Request() req: any) {
+    const wallet = req.user?.wallet || req.headers['x-user-wallet'];
+    if (!wallet) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
     return this.callsService.report(+id, reason);
   }
 

--- a/packages/backend/src/calls/calls.service.ts
+++ b/packages/backend/src/calls/calls.service.ts
@@ -19,7 +19,10 @@ export class CallsService {
   }
 
   async findAll(options?: { chain?: 'base' | 'stellar' }): Promise<Call[]> {
-    const where = options?.chain ? { chain: options.chain } : {};
+    const where: any = { isHidden: false };
+    if (options?.chain) {
+      where.chain = options.chain;
+    }
     return this.callsRepository.find({
       where,
       order: { createdAt: 'DESC' },
@@ -32,8 +35,19 @@ export class CallsService {
   }
 
   async report(id: number, reason: string): Promise<{ success: boolean; message: string }> {
-    // Standard implementation for logging reports against an ID without a dedicated Database Table
-    console.log(`[Report Received] Call ID: ${id} | Reason: ${reason}`);
+    const call = await this.callsRepository.findOne({ where: { id } });
+    if (!call) {
+      return { success: false, message: 'Call not found' };
+    }
+
+    call.reportCount += 1;
+    if (call.reportCount >= 5) {
+      call.isHidden = true;
+    }
+
+    await this.callsRepository.save(call);
+
+    console.log(`[Report Received] Call ID: ${id} | Reason: ${reason} | Report Count: ${call.reportCount}`);
     return { success: true, message: 'Report submitted successfully' };
   }
 

--- a/packages/backend/src/feed/feed.service.ts
+++ b/packages/backend/src/feed/feed.service.ts
@@ -32,7 +32,7 @@ export class FeedService {
 
     // 2. Get calls from these wallets
     return this.callRepository.find({
-      where: { creatorWallet: In(followingWallets) },
+      where: { creatorWallet: In(followingWallets), isHidden: false },
       order: { createdAt: 'DESC' },
       take: limit,
       skip: offset,
@@ -50,6 +50,7 @@ export class FeedService {
     return this.callRepository
       .createQueryBuilder('call')
       .leftJoinAndSelect('call.creator', 'creator')
+      .where('call.isHidden = :isHidden', { isHidden: false })
       .addSelect('(call.totalStakeYes + call.totalStakeNo)', 'total_stake')
       .orderBy('total_stake', 'DESC')
       .addOrderBy('call.createdAt', 'DESC')

--- a/packages/backend/src/search/search.service.ts
+++ b/packages/backend/src/search/search.service.ts
@@ -77,10 +77,11 @@ export class SearchService {
         c."createdAt"
       FROM "call" c
       WHERE
-        to_tsvector('english', coalesce(c.title, '') || ' ' || coalesce(c.description, ''))
+        (to_tsvector('english', coalesce(c.title, '') || ' ' || coalesce(c.description, ''))
           @@ plainto_tsquery('english', $1)
         OR c.title ILIKE $2
-        OR c.description ILIKE $2
+        OR c.description ILIKE $2)
+        AND c."isHidden" = false
       ORDER BY
         ts_rank(
           to_tsvector('english', coalesce(c.title, '') || ' ' || coalesce(c.description, '')),


### PR DESCRIPTION
Closes #82

---

Implement Call Reporting and Auto-Hiding

Description :
To maintain platform quality, this PR implements a flagging and hiding system for inappropriate market titles or descriptions.

Key Changes :

- Entity Update : Added isHidden (boolean) and reportCount (integer) to call.entity.ts .
- Reporting Endpoint : Added POST /calls/:id/report in calls.controller.ts which increments the report count and triggers the auto-hide logic in calls.service.ts .
- Auto-Hide Logic : Calls are automatically set to isHidden = true once the reportCount reaches the threshold of 5.
- Global Filtering : Updated feed.service.ts and search.service.ts to exclude hidden calls from all feed and search results.
- Dependency Fix : Resolved numerous "Cannot find module" diagnostics by running npm install in the backend package.
Acceptance Criteria Verified :

- isHidden and reportCount exist in Call entity.
- POST /calls/:id/report increments count.
- Auto-hides after 5 reports.
- Hidden calls filtered from /feed and search results.
close issue #82 