### PR TITLE
feat(backend): GET /analytics/price-history with Redis cache (#80)

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@keyv/redis": "^3.0.1",
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -18,6 +20,7 @@
         "@nestjs/schedule": "^6.1.1",
         "@nestjs/typeorm": "^11.0.0",
         "@stellar/stellar-sdk": "^14.4.3",
+        "cache-manager": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
         "dotenv": "^17.3.1",
@@ -1328,6 +1331,12 @@
         }
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1958,6 +1967,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/redis": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-3.0.1.tgz",
+      "integrity": "sha512-eyqzomQC76LjUOEkPP8rdR2Fk4eZBSS0Ma47i7CNiQuv8NCw3trZvghx8L5Xruk7XPEj/eRAMrAxP//xQFOPdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ioredis": "^5.4.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2288,6 +2315,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.1.0.tgz",
+      "integrity": "sha512-pEIqYZrBcE8UdkJmZRduurvoUfdU+3kRPeO1R2muiMbZnRuqlki5klFFNllO9LyYWzrx98bd1j0PSPKSJk1Wbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -5219,6 +5259,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-6.4.3.tgz",
+      "integrity": "sha512-VV5eq/QQ5rIVix7/aICO4JyvSeEv9eIQuKL5iFwgM2BrcYoE0A/D1mNsAHJAsB0WEbNdBlKkn6Tjz6fKzh/cKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.3.3"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -5246,6 +5295,16 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/call-bind": {
@@ -5548,6 +5607,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -5955,6 +6023,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6930,6 +7007,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -7631,6 +7718,30 @@
       "license": "ISC",
       "dependencies": {
         "kind-of": "^6.0.2"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8682,13 +8793,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kind-of": {
@@ -8801,6 +8911,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -10085,6 +10207,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -10712,6 +10855,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -32,6 +33,8 @@
     "@stellar/stellar-sdk": "^14.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "@keyv/redis": "^3.0.1",
+    "cache-manager": "^6.0.0",
     "dotenv": "^17.3.1",
     "ethers": "^6.15.0",
     "pg": "^8.16.3",

--- a/packages/backend/src/analytics/analytics.controller.ts
+++ b/packages/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service';
+import { PriceHistoryPeriod, PriceHistoryQueryDto } from './dto/price-history-query.dto';
+
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  /**
+   * GET /analytics/price-history?tokenAddress=<address>&period=7d|30d
+   *
+   * Returns hourly OHLCV close prices formatted as [timestamp_ms, price] tuples,
+   * sorted ascending. Results are cached in Redis for 10 minutes.
+   */
+  @Get('price-history')
+  getPriceHistory(@Query() query: PriceHistoryQueryDto) {
+    const period = query.period ?? PriceHistoryPeriod.SEVEN_DAYS;
+    return this.analyticsService.getPriceHistory(query.tokenAddress, period);
+  }
+}

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+@Module({
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/packages/backend/src/analytics/analytics.service.ts
+++ b/packages/backend/src/analytics/analytics.service.ts
@@ -1,0 +1,151 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
+import { PriceHistoryPeriod } from './dto/price-history-query.dto';
+
+// [timestamp_ms, close_price]
+export type PriceCandle = [number, number];
+
+export interface PriceHistoryResult {
+  tokenAddress: string;
+  period: PriceHistoryPeriod;
+  candles: PriceCandle[];
+}
+
+interface DexScreenerPair {
+  pairAddress: string;
+  chainId: string;
+}
+
+interface DexScreenerTokenResponse {
+  pairs: DexScreenerPair[] | null;
+}
+
+// ohlcv_list entry: [timestamp_s, open, high, low, close, volume]
+type OhlcvEntry = [number, number, number, number, number, number];
+
+interface GeckoOhlcvResponse {
+  data: {
+    attributes: {
+      ohlcv_list: OhlcvEntry[];
+    };
+  };
+}
+
+// Maps DexScreener chainId → GeckoTerminal network slug
+const CHAIN_TO_GECKO_NETWORK: Record<string, string> = {
+  ethereum: 'eth',
+  base: 'base',
+  bsc: 'bsc',
+  arbitrum: 'arbitrum',
+  polygon: 'polygon_pos',
+  solana: 'solana',
+  avalanche: 'avax',
+  optimism: 'optimism',
+  fantom: 'ftm',
+  cronos: 'cro',
+};
+
+// Number of hourly candles to request per period
+const PERIOD_LIMIT: Record<PriceHistoryPeriod, number> = {
+  [PriceHistoryPeriod.SEVEN_DAYS]: 168,  // 7 × 24
+  [PriceHistoryPeriod.THIRTY_DAYS]: 720, // 30 × 24
+};
+
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  async getPriceHistory(
+    tokenAddress: string,
+    period: PriceHistoryPeriod,
+  ): Promise<PriceHistoryResult> {
+    const cacheKey = `price-history:${tokenAddress}:${period}`;
+
+    const cached = await this.cache.get<PriceHistoryResult>(cacheKey);
+    if (cached) {
+      this.logger.debug(`Cache hit: ${cacheKey}`);
+      return cached;
+    }
+
+    this.logger.log(`Cache miss: ${cacheKey} — fetching from external APIs`);
+
+    const { pairAddress, chainId } = await this.resolvePair(tokenAddress);
+    const network = CHAIN_TO_GECKO_NETWORK[chainId.toLowerCase()];
+
+    if (!network) {
+      throw new NotFoundException(
+        `Price history is not supported for chain "${chainId}"`,
+      );
+    }
+
+    const candles = await this.fetchOhlcv(network, pairAddress, period);
+    const result: PriceHistoryResult = { tokenAddress, period, candles };
+
+    await this.cache.set(cacheKey, result, CACHE_TTL_MS);
+
+    return result;
+  }
+
+  private async resolvePair(
+    tokenAddress: string,
+  ): Promise<{ pairAddress: string; chainId: string }> {
+    const url = `https://api.dexscreener.com/latest/dex/tokens/${tokenAddress}`;
+
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `DexScreener returned ${response.status} for token ${tokenAddress}`,
+      );
+    }
+
+    const data = (await response.json()) as DexScreenerTokenResponse;
+    const pair = data?.pairs?.[0];
+
+    if (!pair?.pairAddress) {
+      throw new NotFoundException(
+        `No trading pair found on DexScreener for token ${tokenAddress}`,
+      );
+    }
+
+    return { pairAddress: pair.pairAddress, chainId: pair.chainId };
+  }
+
+  private async fetchOhlcv(
+    network: string,
+    poolAddress: string,
+    period: PriceHistoryPeriod,
+  ): Promise<PriceCandle[]> {
+    const limit = PERIOD_LIMIT[period];
+    const url =
+      `https://api.geckoterminal.com/api/v2/networks/${network}/pools/${poolAddress}/ohlcv/hour` +
+      `?aggregate=1&limit=${limit}`;
+
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `GeckoTerminal returned ${response.status} for ${network}/${poolAddress}`,
+      );
+    }
+
+    const data = (await response.json()) as GeckoOhlcvResponse;
+    const ohlcvList = data?.data?.attributes?.ohlcv_list ?? [];
+
+    // Convert [timestamp_s, open, high, low, close, volume] → [timestamp_ms, close]
+    // GeckoTerminal returns newest-first; sort ascending for chart libraries.
+    return ohlcvList
+      .map(([ts, , , , close]) => [ts * 1000, close] as PriceCandle)
+      .sort(([a], [b]) => a - b);
+  }
+}

--- a/packages/backend/src/analytics/dto/price-history-query.dto.ts
+++ b/packages/backend/src/analytics/dto/price-history-query.dto.ts
@@ -1,0 +1,16 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export enum PriceHistoryPeriod {
+  SEVEN_DAYS = '7d',
+  THIRTY_DAYS = '30d',
+}
+
+export class PriceHistoryQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  tokenAddress: string;
+
+  @IsOptional()
+  @IsEnum(PriceHistoryPeriod)
+  period?: PriceHistoryPeriod;
+}

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
+import { CacheModule } from '@nestjs/cache-manager';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { User } from './users/user.entity';
@@ -18,11 +19,26 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { Notification } from './notifications/notification.entity';
 import { LeaderboardModule } from './leaderboard/leaderboard.module';
 import { PlatformSettings } from './indexer/platform-settings.entity';
+import { AnalyticsModule } from './analytics/analytics.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
+    }),
+    CacheModule.registerAsync({
+      isGlobal: true,
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => {
+        const redisUrl = configService.get<string>('REDIS_URL');
+        if (redisUrl) {
+          const KeyvRedis = (await import('@keyv/redis')).default;
+          return { stores: [new KeyvRedis(redisUrl)] };
+        }
+        // Fall back to in-memory store when REDIS_URL is not configured
+        return {};
+      },
+      inject: [ConfigService],
     }),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),
@@ -49,6 +65,7 @@ import { PlatformSettings } from './indexer/platform-settings.entity';
     FeedModule,
     NotificationsModule,
     LeaderboardModule,
+    AnalyticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],


### PR DESCRIPTION
## Summary

- Adds `GET /analytics/price-history?tokenAddress=\<address\>&period=7d|30d` endpoint
- Resolves token → trading pair via DexScreener, then fetches hourly OHLCV candles from GeckoTerminal
- Returns `[timestamp_ms, close_price]` tuples sorted ascending, ready for charting libraries
- Caches payloads in Redis with a 10-minute TTL (`REDIS_URL` env var); falls back to in-memory store when Redis is not configured
- Adds `@nestjs/cache-manager`, `cache-manager`, and `@keyv/redis` packages
- Registers `CacheModule` globally in `AppModule` and wires in the new `AnalyticsModule`

## New env var
| Variable | Description |
|---|---|
| `REDIS_URL` | Redis connection string (e.g. `redis://localhost:6379`). Optional — omit to use in-memory cache. |

Closes #80