### PR TITLE
Implemented multi-oracle concensus

### DIFF
--- a/packages/contracts/src/OutcomeManager.sol
+++ b/packages/contracts/src/OutcomeManager.sol
@@ -13,24 +13,56 @@ contract OutcomeManager is EIP712, Ownable {
 
     bytes32 public constant OUTCOME_TYPEHASH =
         keccak256("Outcome(uint256 callId,bool outcome,uint256 finalPrice,uint256 timestamp)");
+    
+    // Mapping of authorized oracles
     mapping(address => bool) public authorizedOracle;
+    
+    // Total count of authorized oracles (for quorum calculation)
+    uint256 public totalOracles;
+    
+    // Mapping to track which oracles have signed for each call
+    // callId => oracle => bool (has signed)
+    mapping(uint256 => mapping(address => bool)) public hasSigned;
+    
+    // Mapping to track signature count for each call
+    mapping(uint256 => uint256) public signatureCount;
+    
+    // Mapping to track settled calls
     mapping(uint256 => bool) public settled;
+    
+    // Mapping to store final outcome once quorum is reached
+    mapping(uint256 => bool) public finalOutcome;
+    mapping(uint256 => uint256) public finalPrice;
+    
+    // Quorum threshold - number of signatures required (e.g., 2 for 2/3)
+    uint256 public constant QUORUM_THRESHOLD = 2;
 
     event OutcomeSubmitted(uint256 indexed callId, bool outcome, uint256 finalPrice, address oracle);
+    event OutcomeSettled(uint256 indexed callId, bool outcome, uint256 finalPrice, uint256 signatureCount);
     event PayoutWithdrawn(uint256 indexed callId, address indexed recipient, uint256 amount);
+    event OracleAuthorizationChanged(address indexed oracle, bool status);
 
     constructor(address _registry) EIP712("OnChainSageOutcome", "1") Ownable(msg.sender) {
         registry = CallRegistry(_registry);
     }
 
     function setOracle(address _oracle, bool _status) external onlyOwner {
+        // Update total oracles count when adding/removing
+        if (_status && !authorizedOracle[_oracle]) {
+            totalOracles++;
+        } else if (!_status && authorizedOracle[_oracle]) {
+            require(totalOracles > 0, "No oracles to remove");
+            totalOracles--;
+        }
+        
         authorizedOracle[_oracle] = _status;
+        emit OracleAuthorizationChanged(_oracle, _status);
     }
 
     function submitOutcome(
         uint256 callId,
         bool outcome,
-        uint256 finalPrice,
+        uint256 finalPriceArg,
         uint256 _timestamp,
         bytes calldata signature
     ) external {
@@ -49,7 +81,7 @@ contract OutcomeManager is EIP712, Ownable {
             mstore(ptr, typeHash)
             mstore(add(ptr, 0x20), callId)
             mstore(add(ptr, 0x40), outcome)
-            mstore(add(ptr, 0x60), finalPrice)
+            mstore(add(ptr, 0x60), finalPriceArg)
             mstore(add(ptr, 0x80), _timestamp)
             structHash := keccak256(ptr, 0xa0)
         }
@@ -57,12 +89,55 @@ contract OutcomeManager is EIP712, Ownable {
         address signer = ECDSA.recover(digest, signature);
 
         require(authorizedOracle[signer], "Invalid oracle");
+        
+        // Prevent double-signing by the same oracle
+        require(!hasSigned[callId][signer], "Oracle already signed for this call");
 
-        settled[callId] = true;
-        // In a real implementation, we would call back to Registry to update state
-        // For this MVP, we track settlement here and allow withdrawals based on this state
+        // Record the signature
+        hasSigned[callId][signer] = true;
+        signatureCount[callId]++;
+        
+        // Store the outcome data (all oracles must agree on outcome)
+        finalOutcome[callId] = outcome;
+        finalPrice[callId] = finalPriceArg;
 
-        emit OutcomeSubmitted(callId, outcome, finalPrice, signer);
+        emit OutcomeSubmitted(callId, outcome, finalPriceArg, signer);
+
+        // Check if quorum threshold is reached
+        if (signatureCount[callId] >= QUORUM_THRESHOLD) {
+            settled[callId] = true;
+            // In a real implementation, we would call back to Registry to update state
+            // For this MVP, we track settlement here and allow withdrawals based on this state
+            
+            emit OutcomeSettled(callId, finalOutcome[callId], finalPrice[callId], signatureCount[callId]);
+        }
+    }
+
+    /**
+     * @notice Get the number of signatures collected for a call
+     * @param callId The ID of the call
+     * @return The number of unique oracle signatures received
+     */
+    function getSignatureCount(uint256 callId) external view returns (uint256) {
+        return signatureCount[callId];
+    }
+
+    /**
+     * @notice Check if a specific oracle has signed for a call
+     * @param callId The ID of the call
+     * @param oracle The oracle address to check
+     * @return Whether the oracle has signed
+     */
+    function getHasSigned(uint256 callId, address oracle) external view returns (bool) {
+        return hasSigned[callId][oracle];
+    }
+
+    /**
+     * @notice Get the quorum threshold
+     * @return The number of signatures required for settlement
+     */
+    function getQuorumThreshold() external pure returns (uint256) {
+        return QUORUM_THRESHOLD;
     }
 
     // Placeholder for withdrawal logic


### PR DESCRIPTION
# closes #122 

Implemented M of N quorum for oracle signature resolution in [OutcomeManager.sol](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:1). The following changes address the single-signature vulnerability:

New Storage Variables:

[QUORUM_THRESHOLD](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:38) (constant = 2) - Number of signatures required for settlement
[hasSigned](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:25) - mapping(uint256 => mapping(address => bool)) tracking which oracle signed for each call
[signatureCount](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:28) - mapping(uint256 => uint256) tracking signature count per call
[totalOracles](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:21) - Counter for authorized oracles
[finalOutcome](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:34) / [finalPrice](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:35) - Store outcome data when quorum is reached
Modified [submitOutcome()](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:62):

Validates signature from authorized oracle
Prevents double-signing by the same oracle (Oracle already signed for this call)
Records signature in hasSigned[callId][signer]
Increments signatureCount[callId]
Only sets settled[callId] = true when signatureCount[callId] >= QUORUM_THRESHOLD
New Helper Functions:

[getSignatureCount(uint256 callId)](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:121) - Returns signature count for a call
[getHasSigned(uint256 callId, address oracle)](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:131) - Checks if specific oracle signed
[getQuorumThreshold()](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:139) - Returns the quorum threshold
New Events:

[OutcomeSettled](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:41) - Emitted when quorum is reached
[OracleAuthorizationChanged](https://02dic3cn2n7issspo49bnejaf17c3044m781i7sckgeoorfiiln9.assets.github.dev/stable/cfbea10c5ffb233ea9177d34726e6056e89913dc/out/vs/workbench/contrib/webview/browser/pre/packages/contracts/src/OutcomeManager.sol:43) - Tracks oracle changes