### PR TITLE
feat(stellar): oracle proposal window, dispute bond, admin resolution…

### DIFF
--- a/packages/contracts-stellar/outcome_manager/interfaces.ts
+++ b/packages/contracts-stellar/outcome_manager/interfaces.ts
@@ -3,13 +3,33 @@
  * Use these types for off-chain interactions
  */
 
+/** Mirrors Rust `CallLifecycle` (Soroban `contracttype`). */
+export type CallLifecycle =
+  | { Open: Record<string, never> }
+  | {
+      Proposed: {
+        outcome: boolean;
+        final_price: bigint;
+        window_end_ts: bigint;
+      };
+    }
+  | {
+      Disputed: {
+        proposed_outcome: boolean;
+        proposed_final_price: bigint;
+        disputer: string;
+        bond: bigint;
+      };
+    }
+  | { Settled: Record<string, never> };
+
 export interface CallData {
   id: bigint;
   token: string;
   long_tokens: bigint;
   short_tokens: bigint;
   end_ts: bigint;
-  settled: boolean;
+  lifecycle: CallLifecycle;
   outcome: boolean | null;
   final_price: bigint | null;
 }
@@ -32,10 +52,32 @@ export interface OracleUpdatedEvent {
   authorized: boolean;
 }
 
+export interface OutcomeDisputedEvent {
+  call_id: bigint;
+  staker: string;
+  bond_amount: bigint;
+}
+
+export interface ProposalFinalizedEvent {
+  call_id: bigint;
+  outcome: boolean;
+  final_price: bigint;
+}
+
 export type OutcomeManagerEvent =
   | { OutcomeSubmitted: OutcomeSubmittedEvent }
   | { PayoutWithdrawn: PayoutWithdrawnEvent }
-  | { OracleUpdated: OracleUpdatedEvent };
+  | { OracleUpdated: OracleUpdatedEvent }
+  | { OutcomeDisputed: OutcomeDisputedEvent }
+  | { ProposalFinalized: ProposalFinalizedEvent }
+  | { DisputeResolvedUphold: { call_id: bigint } }
+  | {
+      DisputeResolvedOverride: {
+        call_id: bigint;
+        outcome: boolean;
+        final_price: bigint;
+      };
+    };
 
 export interface SignatureMessage {
   call_id: bigint;
@@ -115,4 +157,11 @@ export function calculatePayout(
  */
 export function canSettleCall(currentTimestamp: bigint, call_end_ts: bigint): boolean {
   return currentTimestamp >= call_end_ts;
+}
+
+/**
+ * True if lifecycle is terminal settled state (payouts allowed once outcome is set).
+ */
+export function isLifecycleSettled(lifecycle: CallLifecycle): boolean {
+  return 'Settled' in lifecycle;
 }

--- a/packages/contracts-stellar/outcome_manager/src/lib.rs
+++ b/packages/contracts-stellar/outcome_manager/src/lib.rs
@@ -11,8 +11,12 @@ const WITHDRAWALS: Symbol = symbol_short!("WITHDRAW");
 const CALL_REGISTRY: Symbol = symbol_short!("CALL_REG");
 const IS_PAUSED: Symbol = symbol_short!("PAUSED");
 const FEE_CONFIG: Symbol = symbol_short!("FEE_CFG");
+const PROPOSAL_WINDOW_SECS: Symbol = symbol_short!("PROPWIN");
 
 const BASIS_POINTS_DENOMINATOR: i128 = 10_000;
+
+/// Default challenge window after the first oracle outcome is recorded (24 hours).
+const DEFAULT_PROPOSAL_WINDOW_SECS: u64 = 86_400;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -22,9 +26,31 @@ pub struct CallData {
     pub long_tokens: u128,
     pub short_tokens: u128,
     pub end_ts: u64,
-    pub settled: bool,
+    pub lifecycle: CallLifecycle,
     pub outcome: Option<bool>,
     pub final_price: Option<u128>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum CallLifecycle {
+    /// No oracle proposal yet.
+    Open,
+    /// Oracle signed outcome is on record; challengers may `dispute_outcome` until `window_end_ts`.
+    Proposed {
+        outcome: bool,
+        final_price: u128,
+        window_end_ts: u64,
+    },
+    /// A bond is locked; owner (admin/DAO) must call a resolve function.
+    Disputed {
+        proposed_outcome: bool,
+        proposed_final_price: u128,
+        disputer: Address,
+        bond: i128,
+    },
+    /// Final; payouts allowed.
+    Settled,
 }
 
 #[contracttype]
@@ -48,6 +74,10 @@ pub enum Event {
     OutcomeSubmitted(u64, bool, u128, BytesN<32>),
     PayoutWithdrawn(u64, Address, u128),
     OracleUpdated(BytesN<32>, bool),
+    OutcomeDisputed(u64, Address, i128),
+    ProposalWindowFinalized(u64, bool, u128),
+    DisputeResolvedUphold(u64),
+    DisputeResolvedOverride(u64, bool, u128),
 }
 
 #[contract]
@@ -77,12 +107,23 @@ impl OutcomeManagerContract {
             .expect("Fee config not set")
     }
 
+    fn proposal_window_secs(env: &Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&PROPOSAL_WINDOW_SECS)
+            .unwrap_or(DEFAULT_PROPOSAL_WINDOW_SECS)
+    }
+
     fn to_i128(value: u128) -> i128 {
         i128::try_from(value).expect("Value exceeds i128 range")
     }
 
     fn to_u128(value: i128) -> u128 {
         u128::try_from(value).expect("Value must be non-negative")
+    }
+
+    fn call_settled(call: &CallData) -> bool {
+        matches!(call.lifecycle, CallLifecycle::Settled)
     }
 
     /// Initialize the contract with owner and call registry address
@@ -118,6 +159,23 @@ impl OutcomeManagerContract {
                 treasury: owner,
             },
         );
+
+        env.storage()
+            .persistent()
+            .set(&PROPOSAL_WINDOW_SECS, &DEFAULT_PROPOSAL_WINDOW_SECS);
+    }
+
+    /// Owner: duration in seconds for the dispute bond window after the first oracle proposal.
+    pub fn set_proposal_window(env: Env, secs: u64) {
+        Self::require_owner_auth(&env);
+        if secs == 0 {
+            panic!("Proposal window must be > 0");
+        }
+        env.storage().persistent().set(&PROPOSAL_WINDOW_SECS, &secs);
+    }
+
+    pub fn get_proposal_window(env: Env) -> u64 {
+        Self::proposal_window_secs(&env)
     }
 
     pub fn set_fee_config(env: Env, basis_points: u32, treasury: Address) {
@@ -179,7 +237,8 @@ impl OutcomeManagerContract {
         oracles.get(oracle).unwrap_or(false)
     }
 
-    /// Submit outcome with ed25519 signature verification
+    /// Submit outcome with ed25519 signature verification.
+    /// Starts the proposal window; call is not final until the window passes without dispute or admin resolves.
     pub fn submit_outcome(
         env: Env,
         call_id: u64,
@@ -192,22 +251,20 @@ impl OutcomeManagerContract {
         Self::assert_not_paused(&env);
         let storage = env.storage().instance();
 
-        // Verify call hasn't been settled
         let mut calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
 
-        if let Some(call_data) = calls.get(call_id) {
-            if call_data.settled {
-                panic!("Call already settled");
-            }
-        } else {
-            panic!("Call not found");
+        let mut call_data = match calls.get(call_id) {
+            Some(c) => c,
+            None => panic!("Call not found"),
+        };
+
+        if !matches!(call_data.lifecycle, CallLifecycle::Open) {
+            panic!("Outcome already proposed or call not open");
         }
 
         // Construct message for signature verification
-        // Format: call_id (8 bytes) + outcome (1 byte) + final_price (16 bytes) + timestamp (8 bytes)
         let mut message = Bytes::new(&env);
 
-        // Add call_id (u64 big-endian)
         message.push_back((call_id >> 56) as u8);
         message.push_back(((call_id >> 48) & 0xFF) as u8);
         message.push_back(((call_id >> 40) & 0xFF) as u8);
@@ -217,15 +274,12 @@ impl OutcomeManagerContract {
         message.push_back(((call_id >> 8) & 0xFF) as u8);
         message.push_back((call_id & 0xFF) as u8);
 
-        // Add outcome (1 byte)
         message.push_back(if outcome { 1u8 } else { 0u8 });
 
-        // Add final_price (u128 big-endian, 16 bytes)
         for i in (0..16).rev() {
             message.push_back(((final_price >> (i * 8)) & 0xFF) as u8);
         }
 
-        // Add timestamp (u64 big-endian)
         message.push_back((timestamp >> 56) as u8);
         message.push_back(((timestamp >> 48) & 0xFF) as u8);
         message.push_back(((timestamp >> 40) & 0xFF) as u8);
@@ -235,34 +289,200 @@ impl OutcomeManagerContract {
         message.push_back(((timestamp >> 8) & 0xFF) as u8);
         message.push_back((timestamp & 0xFF) as u8);
 
-        // Verify ed25519 signature
         env.crypto()
             .ed25519_verify(&oracle_pubkey, &message, &signature);
 
-        // Verify signer is an authorized oracle
         let oracles: Map<BytesN<32>, bool> =
             storage.get(&ORACLES).unwrap_or_else(|| Map::new(&env));
-        let is_authorized = oracles.get(oracle_pubkey.clone()).unwrap_or(false);
-
-        if !is_authorized {
+        if !oracles.get(oracle_pubkey.clone()).unwrap_or(false) {
             panic!("Oracle not authorized");
         }
 
-        // Mark call as settled
-        let mut call_data = calls.get(call_id).unwrap();
-        call_data.settled = true;
-        call_data.outcome = Some(outcome);
-        call_data.final_price = Some(final_price);
+        let now = env.ledger().timestamp();
+        let window = Self::proposal_window_secs(&env);
+        let window_end_ts = now.checked_add(window).expect("Window end overflow");
+
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome,
+            final_price,
+            window_end_ts,
+        };
         calls.set(call_id, call_data);
         storage.set(&CALLS, &calls);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "outcome_submitted"),),
             Event::OutcomeSubmitted(call_id, outcome, final_price, oracle_pubkey),
         );
 
         true
+    }
+
+    /// Anyone may finalize after the proposal window if no dispute was raised.
+    pub fn finalize_proposed_outcome(env: Env, call_id: u64) {
+        Self::assert_not_paused(&env);
+        let storage = env.storage().instance();
+        let mut calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
+
+        let mut call_data = calls.get(call_id).expect("Call not found");
+
+        let (outcome, price, window_end_ts) = match &call_data.lifecycle {
+            CallLifecycle::Proposed {
+                outcome,
+                final_price,
+                window_end_ts,
+            } => (*outcome, *final_price, *window_end_ts),
+            _ => panic!("Call not in proposed state"),
+        };
+
+        if env.ledger().timestamp() < window_end_ts {
+            panic!("Proposal window still active");
+        }
+
+        call_data.lifecycle = CallLifecycle::Settled;
+        call_data.outcome = Some(outcome);
+        call_data.final_price = Some(price);
+        calls.set(call_id, call_data);
+        storage.set(&CALLS, &calls);
+
+        env.events().publish(
+            (Symbol::new(&env, "proposal_finalized"),),
+            Event::ProposalWindowFinalized(call_id, outcome, price),
+        );
+    }
+
+    /// Lock a bond and move the call to `Disputed` during the proposal window.
+    pub fn dispute_outcome(env: Env, call_id: u64, staker: Address, bond_amount: i128) {
+        Self::assert_not_paused(&env);
+        staker.require_auth();
+
+        if bond_amount <= 0 {
+            panic!("Bond amount must be > 0");
+        }
+
+        let storage = env.storage().instance();
+        let mut calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
+
+        let mut call_data = calls.get(call_id).expect("Call not found");
+
+        let (proposed_outcome, proposed_final_price, window_end_ts) = match &call_data.lifecycle {
+            CallLifecycle::Proposed {
+                outcome,
+                final_price,
+                window_end_ts,
+            } => (*outcome, *final_price, *window_end_ts),
+            _ => panic!("Call not disputable"),
+        };
+
+        if env.ledger().timestamp() >= window_end_ts {
+            panic!("Proposal window ended");
+        }
+
+        let token_client = token::Client::new(&env, &call_data.token);
+        token_client.transfer(
+            &staker,
+            &env.current_contract_address(),
+            &bond_amount,
+        );
+
+        call_data.lifecycle = CallLifecycle::Disputed {
+            proposed_outcome,
+            proposed_final_price,
+            disputer: staker.clone(),
+            bond: bond_amount,
+        };
+        calls.set(call_id, call_data);
+        storage.set(&CALLS, &calls);
+
+        env.events().publish(
+            (Symbol::new(&env, "outcome_disputed"),),
+            Event::OutcomeDisputed(call_id, staker, bond_amount),
+        );
+    }
+
+    /// Owner: oracle proposal stands; disputer bond is slashed to treasury (frivolous dispute).
+    pub fn resolve_dispute_uphold_proposal(env: Env, call_id: u64) {
+        Self::require_owner_auth(&env);
+        Self::assert_not_paused(&env);
+
+        let storage = env.storage().instance();
+        let mut calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
+
+        let mut call_data = calls.get(call_id).expect("Call not found");
+
+        let (proposed_outcome, proposed_final_price, bond) = match &call_data.lifecycle {
+            CallLifecycle::Disputed {
+                proposed_outcome,
+                proposed_final_price,
+                bond,
+                ..
+            } => (*proposed_outcome, *proposed_final_price, *bond),
+            _ => panic!("Call not disputed"),
+        };
+
+        let fee_config = Self::get_fee_config(&env);
+        let token_client = token::Client::new(&env, &call_data.token);
+
+        if bond > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &fee_config.treasury,
+                &bond,
+            );
+        }
+
+        call_data.lifecycle = CallLifecycle::Settled;
+        call_data.outcome = Some(proposed_outcome);
+        call_data.final_price = Some(proposed_final_price);
+        calls.set(call_id, call_data);
+        storage.set(&CALLS, &calls);
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_resolved_uphold"),),
+            Event::DisputeResolvedUphold(call_id),
+        );
+    }
+
+    /// Owner: override the proposed outcome (DAO/admin resolution); return the bond to the disputer.
+    pub fn resolve_dispute_override(
+        env: Env,
+        call_id: u64,
+        final_outcome: bool,
+        final_price: u128,
+    ) {
+        Self::require_owner_auth(&env);
+        Self::assert_not_paused(&env);
+
+        let storage = env.storage().instance();
+        let mut calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
+
+        let mut call_data = calls.get(call_id).expect("Call not found");
+
+        let (disputer, bond) = match &call_data.lifecycle {
+            CallLifecycle::Disputed {
+                disputer,
+                bond,
+                ..
+            } => (disputer.clone(), *bond),
+            _ => panic!("Call not disputed"),
+        };
+
+        let token_client = token::Client::new(&env, &call_data.token);
+
+        if bond > 0 {
+            token_client.transfer(&env.current_contract_address(), &disputer, &bond);
+        }
+
+        call_data.lifecycle = CallLifecycle::Settled;
+        call_data.outcome = Some(final_outcome);
+        call_data.final_price = Some(final_price);
+        calls.set(call_id, call_data);
+        storage.set(&CALLS, &calls);
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_resolved_override"),),
+            Event::DisputeResolvedOverride(call_id, final_outcome, final_price),
+        );
     }
 
     /// Register a call (called by CallRegistry or stake contract)
@@ -283,7 +503,7 @@ impl OutcomeManagerContract {
             long_tokens,
             short_tokens,
             end_ts,
-            settled: false,
+            lifecycle: CallLifecycle::Open,
             outcome: None,
             final_price: None,
         };
@@ -303,7 +523,6 @@ impl OutcomeManagerContract {
         let storage = env.storage().instance();
         user.require_auth();
 
-        // Check if user already withdrew
         let withdrawals: Map<(u64, Address), bool> =
             storage.get(&WITHDRAWALS).unwrap_or_else(|| Map::new(&env));
 
@@ -313,20 +532,17 @@ impl OutcomeManagerContract {
             }
         }
 
-        // Get call data
         let calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
         let call_data = calls
             .get(call_id)
             .unwrap_or_else(|| panic!("Call not found"));
 
-        // Verify call is settled
-        if !call_data.settled {
+        if !Self::call_settled(&call_data) {
             panic!("Call not settled");
         }
 
         let outcome = call_data.outcome.unwrap();
         let gross_payout: i128 = if user_side == outcome {
-            // User won - calculate their share
             let winning_tokens = if outcome {
                 Self::to_i128(call_data.long_tokens)
             } else {
@@ -341,10 +557,8 @@ impl OutcomeManagerContract {
 
             let user_stake_i128 = Self::to_i128(user_stake);
 
-            // User gets their stake back + their share of losing side
             user_stake_i128 + ((user_stake_i128 * losing_tokens) / winning_tokens)
         } else {
-            // User lost - no payout (their stake is already gone)
             0
         };
 
@@ -359,7 +573,6 @@ impl OutcomeManagerContract {
         };
         let net_payout = gross_payout - fee_amount;
 
-        // Mark withdrawal as done
         let mut new_withdrawals = withdrawals.clone();
         new_withdrawals.set((call_id, user.clone()), true);
         storage.set(&WITHDRAWALS, &new_withdrawals);
@@ -379,7 +592,6 @@ impl OutcomeManagerContract {
 
         let payout = Self::to_u128(net_payout);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "payout_withdrawn"),),
             Event::PayoutWithdrawn(call_id, user, payout),
@@ -393,6 +605,16 @@ impl OutcomeManagerContract {
         let storage = env.storage().instance();
         let calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
         calls.get(call_id)
+    }
+
+    /// True when the call is in `Settled` lifecycle (payouts allowed).
+    pub fn is_call_settled(env: Env, call_id: u64) -> bool {
+        let storage = env.storage().instance();
+        let calls: Map<u64, CallData> = storage.get(&CALLS).unwrap_or_else(|| Map::new(&env));
+        calls
+            .get(call_id)
+            .map(|c| Self::call_settled(&c))
+            .unwrap_or(false)
     }
 
     /// Check if user already withdrew from a call

--- a/packages/contracts-stellar/outcome_manager/src/lib.rs
+++ b/packages/contracts-stellar/outcome_manager/src/lib.rs
@@ -379,11 +379,7 @@ impl OutcomeManagerContract {
         }
 
         let token_client = token::Client::new(&env, &call_data.token);
-        token_client.transfer(
-            &staker,
-            &env.current_contract_address(),
-            &bond_amount,
-        );
+        token_client.transfer(&staker, &env.current_contract_address(), &bond_amount);
 
         call_data.lifecycle = CallLifecycle::Disputed {
             proposed_outcome,
@@ -424,11 +420,7 @@ impl OutcomeManagerContract {
         let token_client = token::Client::new(&env, &call_data.token);
 
         if bond > 0 {
-            token_client.transfer(
-                &env.current_contract_address(),
-                &fee_config.treasury,
-                &bond,
-            );
+            token_client.transfer(&env.current_contract_address(), &fee_config.treasury, &bond);
         }
 
         call_data.lifecycle = CallLifecycle::Settled;
@@ -459,11 +451,7 @@ impl OutcomeManagerContract {
         let mut call_data = calls.get(call_id).expect("Call not found");
 
         let (disputer, bond) = match &call_data.lifecycle {
-            CallLifecycle::Disputed {
-                disputer,
-                bond,
-                ..
-            } => (disputer.clone(), *bond),
+            CallLifecycle::Disputed { disputer, bond, .. } => (disputer.clone(), *bond),
             _ => panic!("Call not disputed"),
         };
 

--- a/packages/contracts-stellar/outcome_manager/src/test.rs
+++ b/packages/contracts-stellar/outcome_manager/src/test.rs
@@ -1,8 +1,10 @@
 #![cfg(test)]
 
-use crate::{CallData, OutcomeManagerContract, OutcomeManagerContractClient, CALLS};
+use crate::{
+    CallData, CallLifecycle, OutcomeManagerContract, OutcomeManagerContractClient, CALLS,
+};
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     token, Address, BytesN, Env, IntoVal,
 };
 
@@ -25,6 +27,8 @@ fn test_initialize() {
     let fee_config = client.get_fee_config_view();
     assert_eq!(fee_config.basis_points, 0);
     assert_eq!(fee_config.treasury, owner);
+
+    assert_eq!(client.get_proposal_window(), 86_400);
 }
 
 #[test]
@@ -78,7 +82,7 @@ fn test_register_call() {
     assert_eq!(call_data.id, call_id);
     assert_eq!(call_data.long_tokens, long_tokens);
     assert_eq!(call_data.short_tokens, short_tokens);
-    assert!(!call_data.settled);
+    assert!(matches!(call_data.lifecycle, CallLifecycle::Open));
 }
 
 #[test]
@@ -134,7 +138,7 @@ fn test_withdraw_payout_long_wins() {
         let mut calls: soroban_sdk::Map<u64, CallData> =
             env.storage().instance().get(&CALLS).unwrap();
         let mut call_data = calls.get(call_id).unwrap();
-        call_data.settled = true;
+        call_data.lifecycle = CallLifecycle::Settled;
         call_data.outcome = Some(true);
         call_data.final_price = Some(105u128);
         calls.set(call_id, call_data);
@@ -299,4 +303,247 @@ fn test_set_fee_config_requires_owner_auth() {
         },
     }]);
     client.set_fee_config(&250u32, &treasury);
+}
+
+#[test]
+fn test_finalize_proposed_outcome_after_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OutcomeManagerContract);
+    let client = OutcomeManagerContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&owner, &registry);
+    let call_id = 1u64;
+    client.register_call(&call_id, &token, &1000u128, &500u128, &1_000_000u64);
+
+    let window_end = 500u64;
+    env.as_contract(&contract_id, || {
+        let mut calls: soroban_sdk::Map<u64, CallData> =
+            env.storage().instance().get(&CALLS).unwrap();
+        let mut call_data = calls.get(call_id).unwrap();
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome: true,
+            final_price: 99u128,
+            window_end_ts: window_end,
+        };
+        calls.set(call_id, call_data);
+        env.storage().instance().set(&CALLS, &calls);
+    });
+
+    env.ledger().set_timestamp(window_end - 1);
+    assert!(!client.is_call_settled(&call_id));
+
+    env.ledger().set_timestamp(window_end);
+    client.finalize_proposed_outcome(&call_id);
+
+    let call = client.get_call(&call_id).unwrap();
+    assert!(matches!(call.lifecycle, CallLifecycle::Settled));
+    assert_eq!(call.outcome, Some(true));
+    assert_eq!(call.final_price, Some(99u128));
+    assert!(client.is_call_settled(&call_id));
+}
+
+#[test]
+#[should_panic(expected = "Proposal window still active")]
+fn test_finalize_proposed_rejects_before_window_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OutcomeManagerContract);
+    let client = OutcomeManagerContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&owner, &registry);
+    let call_id = 2u64;
+    client.register_call(&call_id, &token, &100u128, &100u128, &1_000_000u64);
+
+    let window_end = 600u64;
+    env.ledger().set_timestamp(100);
+
+    env.as_contract(&contract_id, || {
+        let mut calls: soroban_sdk::Map<u64, CallData> =
+            env.storage().instance().get(&CALLS).unwrap();
+        let mut call_data = calls.get(call_id).unwrap();
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome: false,
+            final_price: 1u128,
+            window_end_ts: window_end,
+        };
+        calls.set(call_id, call_data);
+        env.storage().instance().set(&CALLS, &calls);
+    });
+
+    client.finalize_proposed_outcome(&call_id);
+}
+
+#[test]
+fn test_dispute_outcome_and_uphold_slash_bond() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OutcomeManagerContract);
+    let client = OutcomeManagerContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_client = token::Client::new(&env, &stake_token);
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+
+    client.initialize(&owner, &registry);
+    client.set_fee_config(&0u32, &treasury);
+
+    let call_id = 7u64;
+    client.register_call(
+        &call_id,
+        &stake_token,
+        &1000u128,
+        &500u128,
+        &1_000_000u64,
+    );
+
+    let now = 10_000u64;
+    let window_end = now + 86_400;
+    env.ledger().set_timestamp(now);
+
+    env.as_contract(&contract_id, || {
+        let mut calls: soroban_sdk::Map<u64, CallData> =
+            env.storage().instance().get(&CALLS).unwrap();
+        let mut call_data = calls.get(call_id).unwrap();
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome: false,
+            final_price: 50u128,
+            window_end_ts: window_end,
+        };
+        calls.set(call_id, call_data);
+        env.storage().instance().set(&CALLS, &calls);
+    });
+
+    stake_token_admin_client.mint(&disputer, &200);
+    client.dispute_outcome(&call_id, &disputer, &100i128);
+
+    let call = client.get_call(&call_id).unwrap();
+    assert!(matches!(
+        call.lifecycle,
+        CallLifecycle::Disputed { .. }
+    ));
+    assert_eq!(stake_token_client.balance(&contract_id), 100i128);
+    assert_eq!(stake_token_client.balance(&disputer), 100i128);
+
+    client.resolve_dispute_uphold_proposal(&call_id);
+
+    let settled = client.get_call(&call_id).unwrap();
+    assert!(matches!(settled.lifecycle, CallLifecycle::Settled));
+    assert_eq!(settled.outcome, Some(false));
+    assert_eq!(stake_token_client.balance(&treasury), 100i128);
+    assert_eq!(stake_token_client.balance(&contract_id), 0i128);
+}
+
+#[test]
+fn test_dispute_outcome_and_override_refunds_bond() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OutcomeManagerContract);
+    let client = OutcomeManagerContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_client = token::Client::new(&env, &stake_token);
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+
+    client.initialize(&owner, &registry);
+    client.set_fee_config(&0u32, &treasury);
+
+    let call_id = 8u64;
+    client.register_call(
+        &call_id,
+        &stake_token,
+        &100u128,
+        &100u128,
+        &2_000_000u64,
+    );
+
+    let now = 20_000u64;
+    env.ledger().set_timestamp(now);
+
+    env.as_contract(&contract_id, || {
+        let mut calls: soroban_sdk::Map<u64, CallData> =
+            env.storage().instance().get(&CALLS).unwrap();
+        let mut call_data = calls.get(call_id).unwrap();
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome: true,
+            final_price: 1u128,
+            window_end_ts: now + 3600,
+        };
+        calls.set(call_id, call_data);
+        env.storage().instance().set(&CALLS, &calls);
+    });
+
+    stake_token_admin_client.mint(&disputer, &50);
+    client.dispute_outcome(&call_id, &disputer, &50i128);
+
+    client.resolve_dispute_override(&call_id, &false, &2u128);
+
+    let settled = client.get_call(&call_id).unwrap();
+    assert_eq!(settled.outcome, Some(false));
+    assert_eq!(settled.final_price, Some(2u128));
+    assert_eq!(stake_token_client.balance(&disputer), 50i128);
+    assert_eq!(stake_token_client.balance(&contract_id), 0i128);
+}
+
+#[test]
+#[should_panic(expected = "Call not settled")]
+fn test_withdraw_requires_settled_not_proposed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OutcomeManagerContract);
+    let client = OutcomeManagerContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let user = Address::generate(&env);
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+
+    client.initialize(&owner, &registry);
+
+    let call_id = 3u64;
+    client.register_call(&call_id, &stake_token, &1000u128, &500u128, &1_000_000u64);
+
+    env.as_contract(&contract_id, || {
+        let mut calls: soroban_sdk::Map<u64, CallData> =
+            env.storage().instance().get(&CALLS).unwrap();
+        let mut call_data = calls.get(call_id).unwrap();
+        call_data.lifecycle = CallLifecycle::Proposed {
+            outcome: true,
+            final_price: 1u128,
+            window_end_ts: 999_999_999,
+        };
+        calls.set(call_id, call_data);
+        env.storage().instance().set(&CALLS, &calls);
+    });
+
+    client.withdraw_payout(&call_id, &user, &100u128, &true);
 }

--- a/packages/contracts-stellar/outcome_manager/src/test.rs
+++ b/packages/contracts-stellar/outcome_manager/src/test.rs
@@ -1,8 +1,6 @@
 #![cfg(test)]
 
-use crate::{
-    CallData, CallLifecycle, OutcomeManagerContract, OutcomeManagerContractClient, CALLS,
-};
+use crate::{CallData, CallLifecycle, OutcomeManagerContract, OutcomeManagerContractClient, CALLS};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     token, Address, BytesN, Env, IntoVal,
@@ -407,13 +405,7 @@ fn test_dispute_outcome_and_uphold_slash_bond() {
     client.set_fee_config(&0u32, &treasury);
 
     let call_id = 7u64;
-    client.register_call(
-        &call_id,
-        &stake_token,
-        &1000u128,
-        &500u128,
-        &1_000_000u64,
-    );
+    client.register_call(&call_id, &stake_token, &1000u128, &500u128, &1_000_000u64);
 
     let now = 10_000u64;
     let window_end = now + 86_400;
@@ -436,10 +428,7 @@ fn test_dispute_outcome_and_uphold_slash_bond() {
     client.dispute_outcome(&call_id, &disputer, &100i128);
 
     let call = client.get_call(&call_id).unwrap();
-    assert!(matches!(
-        call.lifecycle,
-        CallLifecycle::Disputed { .. }
-    ));
+    assert!(matches!(call.lifecycle, CallLifecycle::Disputed { .. }));
     assert_eq!(stake_token_client.balance(&contract_id), 100i128);
     assert_eq!(stake_token_client.balance(&disputer), 100i128);
 
@@ -475,13 +464,7 @@ fn test_dispute_outcome_and_override_refunds_bond() {
     client.set_fee_config(&0u32, &treasury);
 
     let call_id = 8u64;
-    client.register_call(
-        &call_id,
-        &stake_token,
-        &100u128,
-        &100u128,
-        &2_000_000u64,
-    );
+    client.register_call(&call_id, &stake_token, &100u128, &100u128, &2_000_000u64);
 
     let now = 20_000u64;
     env.ledger().set_timestamp(now);


### PR DESCRIPTION
On branch 121-oracle-dispute-bond-window, the Stellar outcome_manager was changed so oracle submissions start a 24h (configurable) challenge window instead of settling immediately, dispute_outcome locks a bond and moves the call to Disputed, and the owner resolves disputes by either upholding the proposal (bond slashed to treasury) or overriding the outcome (bond refunded), with finalize_proposed_outcome closing uncontested calls after the window.

closes #121 