### PR TITLE
fix: resolve issues #91, #159, #160, #161

### DIFF
--- a/packages/backend/src/calls/call.entity.ts
+++ b/packages/backend/src/calls/call.entity.ts
@@ -6,10 +6,14 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { User } from '../users/user.entity';
 
 @Entity()
+@Index('IDX_call_status', ['status'])
+@Index('IDX_call_end_ts', ['endTs'])
+@Index('IDX_call_creator_wallet', ['creatorWallet'])
 export class Call {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/backend/src/calls/participant.entity.ts
+++ b/packages/backend/src/calls/participant.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('participants')
+@Index('IDX_participant_call_wallet', ['callId', 'wallet'])
+export class Participant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  callId: string;
+
+  @Column()
+  wallet: string;
+
+  @Column('decimal', { precision: 36, scale: 18, default: 0 })
+  amount: number;
+
+  @Column({ default: true })
+  position: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/backend/src/migration/1745358977000-AddBTreeIndexesAndParticipants.ts
+++ b/packages/backend/src/migration/1745358977000-AddBTreeIndexesAndParticipants.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * AddBTreeIndexesAndParticipants1745358977000
+ *
+ * Resolves issue #91: B-Tree Indexing applied to high-traffic columns.
+ *
+ * Changes:
+ *   - Adds indexes on calls(status), calls(end_ts), calls(creator_wallet)
+ *   - Creates participants table with compound index on (call_id, wallet)
+ */
+export class AddBTreeIndexesAndParticipants1745358977000
+  implements MigrationInterface
+{
+  name = 'AddBTreeIndexesAndParticipants1745358977000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Indexes on calls — skip if already present from initial migration
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_call_status"
+        ON "call" ("status");
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_call_end_ts"
+        ON "call" ("endTs");
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_call_creator_wallet"
+        ON "call" ("creatorWallet");
+    `);
+
+    // Participants table with compound unique-check index
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "participants" (
+        "id"         UUID            NOT NULL DEFAULT gen_random_uuid(),
+        "callId"     VARCHAR(256)    NOT NULL,
+        "wallet"     VARCHAR(256)    NOT NULL,
+        "amount"     NUMERIC(36,18)  NOT NULL DEFAULT 0,
+        "position"   BOOLEAN         NOT NULL DEFAULT true,
+        "createdAt"  TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+        CONSTRAINT "PK_participants" PRIMARY KEY ("id")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_participant_call_wallet"
+        ON "participants" ("callId", "wallet");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_participant_call_wallet";`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "participants";`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_call_creator_wallet";`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_call_end_ts";`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_call_status";`);
+  }
+}

--- a/packages/contracts-stellar/call_registry/src/lib.rs
+++ b/packages/contracts-stellar/call_registry/src/lib.rs
@@ -1,7 +1,21 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, BytesN, Env, String, Symbol,
+    contract, contractimpl, contracttype, token, Address, BytesN, Env, String, Symbol, Vec,
 };
+
+// ── Vault interface (mock / Phoenix-compatible) ───────────────────────────────
+// Any Soroban lending vault that exposes deposit/withdraw is compatible.
+mod vault {
+    use soroban_sdk::{contractclient, Address, Env};
+
+    #[contractclient(name = "VaultClient")]
+    pub trait Vault {
+        fn deposit(env: Env, from: Address, amount: i128);
+        fn withdraw(env: Env, to: Address, amount: i128);
+    }
+}
+
+// ── Data types ────────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,6 +32,10 @@ pub struct Call {
     pub settled: bool,
     pub outcome: bool,
     pub final_price: i128,
+    /// Total funds currently deposited in the vault for this call.
+    pub vault_balance: i128,
+    /// Number of unique participants (used for surge-fee calculation).
+    pub participant_count: u32,
 }
 
 #[contracttype]
@@ -36,7 +54,39 @@ pub enum DataKey {
     UserStake(u64, Address, bool),
     Admin,
     IsPaused,
+    /// Optional vault contract address (set by admin).
+    VaultContract,
+    /// Accumulated platform fees available for dividend distribution.
+    PlatformFees,
 }
+
+// ── Surge-fee helper ──────────────────────────────────────────────────────────
+
+/// Returns fee in basis points (1 bp = 0.01 %).
+/// Base fee: 50 bp (0.5 %).  Each additional 10 participants adds 5 bp, capped at 200 bp (2 %).
+///
+/// | participants | fee bp |
+/// |-------------|--------|
+/// | 0–9         | 50     |
+/// | 10–19       | 55     |
+/// | …           | …      |
+/// | ≥300        | 200    |
+pub fn compute_fee_basis_points(participant_count: u32) -> i128 {
+    const BASE_BPS: i128 = 50;
+    const MAX_BPS: i128 = 200;
+    const STEP: u32 = 10;
+    const BPS_PER_STEP: i128 = 5;
+
+    let steps = (participant_count / STEP) as i128;
+    let fee = BASE_BPS + steps * BPS_PER_STEP;
+    if fee > MAX_BPS {
+        MAX_BPS
+    } else {
+        fee
+    }
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct CallRegistry;
@@ -63,25 +113,63 @@ impl CallRegistry {
         }
     }
 
-    /// Initialize admin and pause state
+    // ── Vault helpers ─────────────────────────────────────────────────────────
+
+    fn vault_contract(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::VaultContract)
+    }
+
+    /// Deposit `amount` into the vault on behalf of the contract.
+    fn vault_deposit(env: &Env, stake_token: &Address, amount: i128) {
+        if let Some(vault_addr) = Self::vault_contract(env) {
+            let client = vault::VaultClient::new(env, &vault_addr);
+            // Approve vault to pull funds from this contract first.
+            let token_client = token::Client::new(env, stake_token);
+            token_client.approve(
+                &env.current_contract_address(),
+                &vault_addr,
+                &amount,
+                &(env.ledger().sequence() + 100),
+            );
+            client.deposit(&env.current_contract_address(), &amount);
+        }
+    }
+
+    /// Withdraw `amount` from the vault back to this contract.
+    fn vault_withdraw(env: &Env, amount: i128) {
+        if let Some(vault_addr) = Self::vault_contract(env) {
+            let client = vault::VaultClient::new(env, &vault_addr);
+            client.withdraw(&env.current_contract_address(), &amount);
+        }
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    /// Initialize admin and pause state.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().persistent().has(&DataKey::Admin) {
             panic!("Contract already initialized");
         }
-
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::IsPaused, &false);
     }
 
-    /// Pause write operations (admin only)
+    /// Set (or clear) the vault contract address (admin only).
+    pub fn set_vault(env: Env, vault: Address) {
+        let admin = Self::get_admin(&env);
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::VaultContract, &vault);
+    }
+
     pub fn pause(env: Env) {
         let admin = Self::get_admin(&env);
         admin.require_auth();
         env.storage().persistent().set(&DataKey::IsPaused, &true);
     }
 
-    /// Resume write operations (admin only)
     pub fn unpause(env: Env) {
         let admin = Self::get_admin(&env);
         admin.require_auth();
@@ -92,12 +180,10 @@ impl CallRegistry {
         Self::is_paused(&env)
     }
 
-    /// Create a new prediction call
-    /// Accepts creator, stake token, stake amount, end timestamp, and call metadata
-    /// Transfers stake from creator to contract (escrow)
-    /// Stores call data in persistent storage
-    /// Emits CallCreated event
-    /// Returns the new call ID
+    // ── Core call lifecycle ───────────────────────────────────────────────────
+
+    /// Create a new prediction call.
+    /// Stakes are deposited into the vault (if configured) to earn yield.
     pub fn create_call(
         env: Env,
         creator: Address,
@@ -120,7 +206,9 @@ impl CallRegistry {
         let token_client = token::Client::new(&env, &stake_token);
         token_client.transfer(&creator, &env.current_contract_address(), &stake_amount);
 
-        // Get and increment ID
+        // Deposit into vault (issue #159)
+        Self::vault_deposit(&env, &stake_token, stake_amount);
+
         let call_id = env
             .storage()
             .instance()
@@ -145,22 +233,19 @@ impl CallRegistry {
             settled: false,
             outcome: false,
             final_price: 0,
+            vault_balance: stake_amount,
+            participant_count: 1,
         };
 
-        // Store call
         env.storage()
             .persistent()
             .set(&DataKey::Call(call_id), &call);
 
-        // Record creator's stake (YES position)
         env.storage().persistent().set(
             &DataKey::UserStake(call_id, creator.clone(), true),
             &stake_amount,
         );
 
-        // Emit CallCreated event
-        // topics: ["CallCreated", call_id, creator]
-        // data: (stake_token, stake_amount, start_ts, end_ts, token_address, pair_id, ipfs_cid)
         env.events().publish(
             (Symbol::new(&env, "CallCreated"), call_id, creator),
             (
@@ -177,12 +262,9 @@ impl CallRegistry {
         call_id
     }
 
-    /// Stake on an existing call
-    /// Accepts call ID, staker, amount, and position (true=YES, false=NO)
-    /// Validates call exists, hasn't ended, and isn't settled
-    /// Transfers stake to contract
-    /// Updates total_stake_yes or total_stake_no
-    /// Emits StakeAdded event
+    /// Stake on an existing call.
+    /// Applies a dynamic surge fee based on participant count (issue #161).
+    /// Net stake (after fee) is deposited into the vault (issue #159).
     pub fn stake_on_call(env: Env, call_id: u64, staker: Address, amount: i128, position: bool) {
         Self::assert_not_paused(&env);
         staker.require_auth();
@@ -204,33 +286,222 @@ impl CallRegistry {
             panic!("Amount must be > 0");
         }
 
-        // Transfer stake
+        // Transfer full amount from staker to contract
         let token_client = token::Client::new(&env, &call.stake_token);
         token_client.transfer(&staker, &env.current_contract_address(), &amount);
 
-        // Update totals
-        if position {
-            call.total_stake_yes += amount;
-        } else {
-            call.total_stake_no += amount;
+        // Dynamic surge fee (issue #161)
+        let fee_bps = compute_fee_basis_points(call.participant_count);
+        let fee = amount * fee_bps / 10_000;
+        let net_amount = amount - fee;
+
+        // Accumulate platform fee for dividend distribution (issue #160)
+        if fee > 0 {
+            let current_fees: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PlatformFees)
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::PlatformFees, &(current_fees + fee));
         }
+
+        // Deposit net stake into vault (issue #159)
+        Self::vault_deposit(&env, &call.stake_token, net_amount);
+
+        // Update totals with net amount
+        if position {
+            call.total_stake_yes += net_amount;
+        } else {
+            call.total_stake_no += net_amount;
+        }
+        call.vault_balance += net_amount;
+        call.participant_count += 1;
         env.storage().persistent().set(&key, &call);
 
-        // Update user stake
         let stake_key = DataKey::UserStake(call_id, staker.clone(), position);
         let current_stake: i128 = env.storage().persistent().get(&stake_key).unwrap_or(0);
         env.storage()
             .persistent()
-            .set(&stake_key, &(current_stake + amount));
+            .set(&stake_key, &(current_stake + net_amount));
 
-        // Emit StakeAdded event
-        // topics: ["StakeAdded", call_id, staker]
-        // data: (position, amount)
         env.events().publish(
             (Symbol::new(&env, "StakeAdded"), call_id, staker),
-            (position, amount),
+            (position, net_amount, fee, fee_bps),
         );
     }
+
+    /// Withdraw payout for a settled call.
+    /// Withdraws principal from vault before transferring to winner (issue #159).
+    pub fn withdraw_payout(env: Env, call_id: u64, user: Address, position: bool) {
+        user.require_auth();
+
+        let key = DataKey::Call(call_id);
+        let mut call: Call = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Call does not exist");
+
+        if !call.settled {
+            panic!("Call not settled");
+        }
+        if call.outcome != position {
+            panic!("Not on winning side");
+        }
+
+        let stake_key = DataKey::UserStake(call_id, user.clone(), position);
+        let user_stake: i128 = env
+            .storage()
+            .persistent()
+            .get(&stake_key)
+            .expect("No stake found");
+
+        if user_stake == 0 {
+            panic!("Nothing to withdraw");
+        }
+
+        let winners_pool = if position {
+            call.total_stake_yes
+        } else {
+            call.total_stake_no
+        };
+        let losers_pool = if position {
+            call.total_stake_no
+        } else {
+            call.total_stake_yes
+        };
+
+        // Proportional share of losers pool
+        let payout = user_stake + (user_stake * losers_pool / winners_pool);
+
+        // Withdraw from vault (issue #159); vault keeps the interest
+        Self::vault_withdraw(&env, payout);
+        call.vault_balance -= payout;
+        env.storage().persistent().set(&key, &call);
+
+        // Clear user stake
+        env.storage().persistent().set(&stake_key, &0i128);
+
+        let token_client = token::Client::new(&env, &call.stake_token);
+        token_client.transfer(&env.current_contract_address(), &user, &payout);
+
+        env.events().publish(
+            (Symbol::new(&env, "PayoutWithdrawn"), call_id, user),
+            payout,
+        );
+    }
+
+    // ── Dividend distribution (issue #160) ────────────────────────────────────
+
+    /// Distribute accumulated platform fees proportionally to governance token holders.
+    /// `stakers` is a list of (address, governance_token_balance) pairs.
+    /// The treasury (admin) keeps the interest earned by the vault; only explicit
+    /// platform fees collected via surge pricing are distributed here.
+    pub fn distribute_dividends(
+        env: Env,
+        stake_token: Address,
+        stakers: Vec<(Address, i128)>,
+    ) {
+        let admin = Self::get_admin(&env);
+        admin.require_auth();
+
+        let total_fees: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PlatformFees)
+            .unwrap_or(0);
+
+        if total_fees == 0 {
+            panic!("No fees to distribute");
+        }
+
+        // Compute total governance weight
+        let mut total_weight: i128 = 0;
+        for i in 0..stakers.len() {
+            let (_, weight) = stakers.get(i).unwrap();
+            total_weight += weight;
+        }
+        if total_weight == 0 {
+            panic!("Total weight is zero");
+        }
+
+        let token_client = token::Client::new(&env, &stake_token);
+
+        for i in 0..stakers.len() {
+            let (addr, weight) = stakers.get(i).unwrap();
+            let share = total_fees * weight / total_weight;
+            if share > 0 {
+                token_client.transfer(&env.current_contract_address(), &addr, &share);
+            }
+        }
+
+        // Reset accumulated fees
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformFees, &0i128);
+
+        env.events().publish(
+            (Symbol::new(&env, "DividendsDistributed"),),
+            (total_fees, total_weight),
+        );
+    }
+
+    // ── Finalize ──────────────────────────────────────────────────────────────
+
+    /// Finalize a call. Deducts a gas fee from the losers' pool.
+    pub fn finalize_call(
+        env: Env,
+        call_id: u64,
+        outcome: bool,
+        final_price: i128,
+        caller: Address,
+    ) {
+        caller.require_auth();
+
+        let key = DataKey::Call(call_id);
+        let mut call: Call = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Call does not exist");
+
+        if call.settled {
+            panic!("Call already settled");
+        }
+        if env.ledger().timestamp() < call.end_ts {
+            panic!("Call has not ended yet");
+        }
+
+        let losers_pool = if outcome {
+            call.total_stake_no
+        } else {
+            call.total_stake_yes
+        };
+
+        let gas_fee = losers_pool * 5 / 1000;
+
+        if gas_fee > 0 {
+            // Withdraw gas fee from vault before paying caller
+            Self::vault_withdraw(&env, gas_fee);
+            call.vault_balance -= gas_fee;
+            let token_client = token::Client::new(&env, &call.stake_token);
+            token_client.transfer(&env.current_contract_address(), &caller, &gas_fee);
+        }
+
+        call.settled = true;
+        call.outcome = outcome;
+        call.final_price = final_price;
+        env.storage().persistent().set(&key, &call);
+
+        env.events().publish(
+            (Symbol::new(&env, "CallFinalized"), call_id, caller),
+            (outcome, final_price, gas_fee),
+        );
+    }
+
+    // ── Getters ───────────────────────────────────────────────────────────────
 
     pub fn get_call(env: Env, call_id: u64) -> Call {
         env.storage()
@@ -245,53 +516,22 @@ impl CallRegistry {
             .get(&DataKey::UserStake(call_id, user, position))
             .unwrap_or(0)
     }
+
+    pub fn get_platform_fees(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PlatformFees)
+            .unwrap_or(0)
+    }
+
+    pub fn get_fee_basis_points(env: Env, call_id: u64) -> i128 {
+        let call: Call = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Call(call_id))
+            .expect("Call does not exist");
+        compute_fee_basis_points(call.participant_count)
+    }
 }
-/// Finalize a call and reward the caller with a gas fee
-/// Deducts 0.5% from the losers' pool as a gas fee
-/// Transfers the fee to the address that calls this function
-pub fn finalize_call(env: Env, call_id: u64, outcome: bool, final_price: i128, caller: Address) {
-    caller.require_auth();
 
-    let key = DataKey::Call(call_id);
-    let mut call: Call = env
-        .storage()
-        .persistent()
-        .get(&key)
-        .expect("Call does not exist");
-
-    if call.settled {
-        panic!("Call already settled");
-    }
-    if env.ledger().timestamp() < call.end_ts {
-        panic!("Call has not ended yet");
-    }
-
-    // Determine losers pool
-    let losers_pool = if outcome {
-        call.total_stake_no
-    } else {
-        call.total_stake_yes
-    };
-
-    // Deduct 0.5% gas fee from losers pool
-    let gas_fee = losers_pool * 5 / 1000;
-
-    // Transfer gas fee to caller
-    if gas_fee > 0 {
-        let token_client = token::Client::new(&env, &call.stake_token);
-        token_client.transfer(&env.current_contract_address(), &caller, &gas_fee);
-    }
-
-    // Mark call as settled
-    call.settled = true;
-    call.outcome = outcome;
-    call.final_price = final_price;
-    env.storage().persistent().set(&key, &call);
-
-    // Emit CallFinalized event
-    env.events().publish(
-        (Symbol::new(&env, "CallFinalized"), call_id, caller),
-        (outcome, final_price, gas_fee),
-    );
-}
 mod test;

--- a/packages/contracts-stellar/call_registry/src/test.rs
+++ b/packages/contracts-stellar/call_registry/src/test.rs
@@ -3,8 +3,39 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger, MockAuth, MockAuthInvoke},
-    Address, BytesN, Env, IntoVal, String,
+    vec, Address, BytesN, Env, IntoVal, String,
 };
+
+fn setup_env() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract =
+        env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+
+    let creator = Address::generate(&env);
+    stake_token_admin_client.mint(&creator, &10_000);
+
+    (env, contract_id, admin, stake_token, creator)
+}
+
+fn default_metadata(env: &Env) -> CreateCallMetadata {
+    CreateCallMetadata {
+        token_address: Address::generate(env),
+        pair_id: BytesN::from_array(env, &[0; 32]),
+        ipfs_cid: String::from_str(env, "QmHash"),
+    }
+}
+
+// ── Existing tests (preserved) ────────────────────────────────────────────────
 
 #[test]
 fn test_create_call() {
@@ -23,43 +54,26 @@ fn test_create_call() {
     let stake_token_client = token::Client::new(&env, &stake_token);
     let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
 
-    // Mint tokens to creator
     stake_token_admin_client.mint(&creator, &1000);
 
     let end_ts = env.ledger().timestamp() + 1000;
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address: token_address.clone(),
-        pair_id: pair_id.clone(),
-        ipfs_cid: ipfs_cid.clone(),
-    };
-
-    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
 
     assert_eq!(call_id, 0);
-
     let call = client.get_call(&call_id);
     assert_eq!(call.creator, creator);
     assert_eq!(call.total_stake_yes, 100);
     assert_eq!(call.total_stake_no, 0);
-    assert_eq!(call.ipfs_cid, ipfs_cid);
+    assert_eq!(call.participant_count, 1);
 
-    // Check creator stake
     let stake = client.get_user_stake(&call_id, &creator, &true);
     assert_eq!(stake, 100);
 
-    // Check token transfer
     assert_eq!(stake_token_client.balance(&creator), 900);
     assert_eq!(stake_token_client.balance(&contract_id), 100);
 
-    // Check events
     let events = env.events().all();
-    // Instead of asserting exact length, verify the last event is CallCreated
     let last_event = events.last().unwrap();
-    assert_eq!(last_event.1.len(), 3); // Symbol, call_id, creator
-                                       // We can check the symbol
     let symbol: Symbol = last_event.1.get(0).unwrap().into_val(&env);
     assert_eq!(symbol, Symbol::new(&env, "CallCreated"));
 }
@@ -79,36 +93,21 @@ fn test_stake_on_call() {
     let stake_token_admin = Address::generate(&env);
     let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
     let stake_token = stake_token_contract.address();
-    let stake_token_client = token::Client::new(&env, &stake_token);
     let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
 
     stake_token_admin_client.mint(&creator, &1000);
     stake_token_admin_client.mint(&staker, &1000);
 
     let end_ts = env.ledger().timestamp() + 1000;
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address: token_address.clone(),
-        pair_id: pair_id.clone(),
-        ipfs_cid: ipfs_cid.clone(),
-    };
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
 
-    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
-
-    // Stake NO
-    client.stake_on_call(&call_id, &staker, &50, &false);
+    client.stake_on_call(&call_id, &staker, &1000, &false);
 
     let call = client.get_call(&call_id);
     assert_eq!(call.total_stake_yes, 100);
-    assert_eq!(call.total_stake_no, 50);
-
-    let staker_stake = client.get_user_stake(&call_id, &staker, &false);
-    assert_eq!(staker_stake, 50);
-
-    assert_eq!(stake_token_client.balance(&staker), 950);
-    assert_eq!(stake_token_client.balance(&contract_id), 150);
+    // 50 bp fee on 1000 = 5; net = 995
+    assert_eq!(call.total_stake_no, 995);
+    assert_eq!(call.participant_count, 2);
 }
 
 #[test]
@@ -116,26 +115,19 @@ fn test_stake_on_call() {
 fn test_create_call_past_end_time() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.initialize(&admin);
     let creator = Address::generate(&env);
     let stake_token = Address::generate(&env);
-
-    let end_ts = env.ledger().timestamp(); // Current time
-
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address,
-        pair_id,
-        ipfs_cid,
-    };
-
-    client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
+    client.create_call(
+        &creator,
+        &stake_token,
+        &100,
+        &env.ledger().timestamp(),
+        &default_metadata(&env),
+    );
 }
 
 #[test]
@@ -143,7 +135,6 @@ fn test_create_call_past_end_time() {
 fn test_stake_ended_call() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -154,27 +145,13 @@ fn test_stake_ended_call() {
     let stake_token_admin = Address::generate(&env);
     let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
     let stake_token = stake_token_contract.address();
-    let _stake_token_client = token::Client::new(&env, &stake_token);
     let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
-
     stake_token_admin_client.mint(&creator, &1000);
     stake_token_admin_client.mint(&staker, &1000);
 
     let end_ts = env.ledger().timestamp() + 100;
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address,
-        pair_id,
-        ipfs_cid,
-    };
-
-    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
-
-    // Fast forward time
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
     env.ledger().set_timestamp(end_ts + 1);
-
     client.stake_on_call(&call_id, &staker, &50, &false);
 }
 
@@ -183,72 +160,47 @@ fn test_stake_ended_call() {
 fn test_create_call_paused() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let stake_token_admin = Address::generate(&env);
-    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
-    let stake_token = stake_token_contract.address();
-    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
-
     client.initialize(&admin);
     client.pause();
 
-    stake_token_admin_client.mint(&creator, &1000);
-
-    let end_ts = env.ledger().timestamp() + 1000;
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address,
-        pair_id,
-        ipfs_cid,
-    };
-
-    client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
+    let creator = Address::generate(&env);
+    let stake_token = Address::generate(&env);
+    client.create_call(
+        &creator,
+        &stake_token,
+        &100,
+        &(env.ledger().timestamp() + 1000),
+        &default_metadata(&env),
+    );
 }
 
 #[test]
 fn test_pause_unpause_flow() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert!(!client.get_is_paused());
+
     let creator = Address::generate(&env);
     let staker = Address::generate(&env);
     let stake_token_admin = Address::generate(&env);
     let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
     let stake_token = stake_token_contract.address();
     let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
-
-    client.initialize(&admin);
-    assert!(!client.get_is_paused());
-
     stake_token_admin_client.mint(&creator, &1000);
     stake_token_admin_client.mint(&staker, &1000);
 
     let end_ts = env.ledger().timestamp() + 1000;
-    let token_address = Address::generate(&env);
-    let pair_id = BytesN::from_array(&env, &[0; 32]);
-    let ipfs_cid = String::from_str(&env, "QmHash");
-    let metadata = CreateCallMetadata {
-        token_address,
-        pair_id,
-        ipfs_cid,
-    };
-
-    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &metadata);
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
 
     client.pause();
     assert!(client.get_is_paused());
-
     client.unpause();
     assert!(!client.get_is_paused());
 
@@ -261,10 +213,7 @@ fn test_pause_requires_admin_auth() {
     let env = Env::default();
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
-    let attacker = Address::generate(&env);
-
     env.mock_auths(&[MockAuth {
         address: &admin,
         invoke: &MockAuthInvoke {
@@ -276,6 +225,7 @@ fn test_pause_requires_admin_auth() {
     }]);
     client.initialize(&admin);
 
+    let attacker = Address::generate(&env);
     env.mock_auths(&[MockAuth {
         address: &attacker,
         invoke: &MockAuthInvoke {
@@ -294,10 +244,7 @@ fn test_unpause_requires_admin_auth() {
     let env = Env::default();
     let contract_id = env.register_contract(None, CallRegistry);
     let client = CallRegistryClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
-    let attacker = Address::generate(&env);
-
     env.mock_auths(&[MockAuth {
         address: &admin,
         invoke: &MockAuthInvoke {
@@ -320,6 +267,7 @@ fn test_unpause_requires_admin_auth() {
     }]);
     client.pause();
 
+    let attacker = Address::generate(&env);
     env.mock_auths(&[MockAuth {
         address: &attacker,
         invoke: &MockAuthInvoke {
@@ -330,4 +278,136 @@ fn test_unpause_requires_admin_auth() {
         },
     }]);
     client.unpause();
+}
+
+// ── Issue #161: Dynamic surge fee ────────────────────────────────────────────
+
+#[test]
+fn test_surge_fee_basis_points() {
+    // 0 participants → 50 bp
+    assert_eq!(compute_fee_basis_points(0), 50);
+    // 10 participants → 55 bp
+    assert_eq!(compute_fee_basis_points(10), 55);
+    // 100 participants → 100 bp
+    assert_eq!(compute_fee_basis_points(100), 100);
+    // 300 participants → capped at 200 bp
+    assert_eq!(compute_fee_basis_points(300), 200);
+    // 1000 participants → still capped at 200 bp
+    assert_eq!(compute_fee_basis_points(1000), 200);
+}
+
+#[test]
+fn test_stake_applies_surge_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let staker = Address::generate(&env);
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+    stake_token_admin_client.mint(&creator, &10_000);
+    stake_token_admin_client.mint(&staker, &10_000);
+
+    let end_ts = env.ledger().timestamp() + 1000;
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
+
+    // participant_count = 1 → fee_bps = 50; stake 10_000 → fee = 5, net = 9_995
+    client.stake_on_call(&call_id, &staker, &10_000, &false);
+
+    let call = client.get_call(&call_id);
+    assert_eq!(call.total_stake_no, 9_995);
+    assert_eq!(call.participant_count, 2);
+
+    // Platform fees should have accumulated
+    let fees = client.get_platform_fees();
+    assert_eq!(fees, 5);
+}
+
+#[test]
+fn test_get_fee_basis_points() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+    stake_token_admin_client.mint(&creator, &1000);
+
+    let end_ts = env.ledger().timestamp() + 1000;
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
+
+    // 1 participant → 50 bp
+    assert_eq!(client.get_fee_basis_points(&call_id), 50);
+}
+
+// ── Issue #160: distribute_dividends ─────────────────────────────────────────
+
+#[test]
+fn test_distribute_dividends() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let creator = Address::generate(&env);
+    let staker = Address::generate(&env);
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+    let stake_token_client = token::Client::new(&env, &stake_token);
+    let stake_token_admin_client = token::StellarAssetClient::new(&env, &stake_token);
+    stake_token_admin_client.mint(&creator, &10_000);
+    stake_token_admin_client.mint(&staker, &10_000);
+
+    let end_ts = env.ledger().timestamp() + 1000;
+    let call_id = client.create_call(&creator, &stake_token, &100, &end_ts, &default_metadata(&env));
+
+    // Stake to generate fees: 10_000 * 50bp / 10_000 = 5 fee
+    client.stake_on_call(&call_id, &staker, &10_000, &false);
+    assert_eq!(client.get_platform_fees(), 5);
+
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    // Distribute: holder_a has weight 3, holder_b has weight 2 → total 5
+    // holder_a gets 5 * 3/5 = 3, holder_b gets 5 * 2/5 = 2
+    let stakers = vec![&env, (holder_a.clone(), 3i128), (holder_b.clone(), 2i128)];
+    client.distribute_dividends(&stake_token, &stakers);
+
+    assert_eq!(stake_token_client.balance(&holder_a), 3);
+    assert_eq!(stake_token_client.balance(&holder_b), 2);
+    assert_eq!(client.get_platform_fees(), 0);
+}
+
+#[test]
+#[should_panic(expected = "No fees to distribute")]
+fn test_distribute_dividends_no_fees() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, CallRegistry);
+    let client = CallRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let stake_token_admin = Address::generate(&env);
+    let stake_token_contract = env.register_stellar_asset_contract_v2(stake_token_admin.clone());
+    let stake_token = stake_token_contract.address();
+
+    let holder = Address::generate(&env);
+    let stakers = vec![&env, (holder.clone(), 1i128)];
+    client.distribute_dividends(&stake_token, &stakers);
 }


### PR DESCRIPTION
#91 - Add @Index decorators to Call entity (status, endTs, creatorWallet)
     - Add Participant entity with compound index on (callId, wallet)
     - Add migration 1745358977000-AddBTreeIndexesAndParticipants

#159 - Vault integration in CallRegistry: deposit on stake_on_call/create_call,
       withdraw on withdraw_payout and finalize_call (mock vault interface)

#160 - distribute_dividends: distributes accumulated platform fees proportionally
       to governance token holders (address, weight) pairs

#161 - Dynamic surge fee: compute_fee_basis_points() scales from 50bp base,
       +5bp per 10 participants, capped at 200bp; fee accumulated as PlatformFees
       
 closes #91 
closes #159 
closes #160 
closes #161 