### PR TITLE
Contract/backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,147 @@ soroban contract test
 └─────────────────────────────────────────────────────────────┘
 ```
 
+$ pnpm run test:cov
+```
+
+# WebSocket Events Gateway
+
+Location: `packages/backend/src/gateways/`
+
+## Architecture
+
+```
+Client (browser / mobile)
+   │  Socket.io ws://api/events
+   │
+   ▼
+EventsGateway  (/events namespace)
+   │
+   ├─ handleConnection()       → auto-joins user:<id> room if JWT present
+   ├─ subscribeMarket          → joins  market:<marketId> room
+   ├─ unsubscribeMarket        → leaves market:<marketId> room
+   └─ authenticate             → mid-session login → joins user:<id> room
+   │
+   └─ @OnEvent() listeners ←── EventEmitter2 (from service layer / Issue 9)
+         stake.created         → broadcast → market:<id>
+         price.updated         → broadcast → market:<id>
+         outcome.proposed      → broadcast → market:<id>
+         dispute.raised        → broadcast → market:<id> + user:<staker>
+         dispute.resolved      → broadcast → market:<id> + user:<staker>
+         user.notification     → send     → user:<id>
+```
+
+## Installation
+
+```bash
+npm install @nestjs/websockets @nestjs/platform-socket.io socket.io @nestjs/event-emitter
+```
+
+## AppModule wiring
+
+See `app.module.snippet.ts`. The two required additions are:
+1. `EventEmitterModule.forRoot({ wildcard: true, delimiter: '.' })`
+2. `GatewaysModule`
+
+## Client usage
+
+### Connect (anonymous — public market data only)
+
+```typescript
+import { io } from 'socket.io-client';
+
+const socket = io('wss://api.example.com/events', {
+  transports: ['websocket'],
+});
+
+// Subscribe to a market
+socket.emit('subscribeMarket', { marketId: 'mkt-abc' });
+
+// Receive live events
+socket.on('stakeCreated',    (data) => console.log('new stake', data));
+socket.on('priceUpdated',    (data) => console.log('price',     data));
+socket.on('outcomeProposed', (data) => console.log('outcome',   data));
+socket.on('disputeRaised',   (data) => console.log('dispute',   data));
+socket.on('disputeResolved', (data) => console.log('resolved',  data));
+```
+
+### Connect (authenticated — private notifications)
+
+**Option A** — JWT in Authorization header at connection time:
+
+```typescript
+const socket = io('wss://api.example.com/events', {
+  transports: ['websocket'],
+  extraHeaders: { Authorization: `Bearer ${token}` },
+});
+```
+
+**Option B** — Authenticate after connecting (SPA login flow):
+
+```typescript
+socket.emit('authenticate', { token: jwtToken });
+socket.on('authenticated', ({ userId }) => console.log('logged in as', userId));
+```
+
+Private notifications arrive on the `notification` event:
+
+```typescript
+socket.on('notification', ({ type, payload, timestamp }) => {
+  console.log(`[${type}]`, payload);
+});
+```
+
+## Emitting events from your service layer
+
+Inject `EventEmitter2` and emit with the dot-delimited keys the gateway listens to:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { StakeCreatedEvent } from '../gateways/events.types';
+
+@Injectable()
+export class StakesService {
+  constructor(private readonly emitter: EventEmitter2) {}
+
+  async createStake(...) {
+    // ... business logic ...
+
+    this.emitter.emit('stake.created', {
+      marketId: stake.marketId,
+      staker: stake.stakerAddress,
+      amount: stake.amount.toString(),
+      outcomeIndex: stake.outcomeIndex,
+      timestamp: Date.now(),
+      txHash: tx.hash,
+    } satisfies StakeCreatedEvent);
+  }
+}
+```
+
+## Event payload reference
+
+| EventEmitter2 key   | Socket.io client event | Room(s) notified                      |
+|---------------------|------------------------|---------------------------------------|
+| `stake.created`     | `stakeCreated`         | `market:<id>`                         |
+| `price.updated`     | `priceUpdated`         | `market:<id>`                         |
+| `outcome.proposed`  | `outcomeProposed`      | `market:<id>`                         |
+| `dispute.raised`    | `disputeRaised`        | `market:<id>` + `user:<staker>`       |
+| `dispute.resolved`  | `disputeResolved`      | `market:<id>` + `user:<staker>`       |
+| `user.notification` | `notification`         | `user:<id>`                           |
+
+## Imperative broadcasts (inject EventsGateway directly)
+
+```typescript
+constructor(private readonly eventsGateway: EventsGateway) {}
+
+// Broadcast to all clients watching a market
+this.eventsGateway.broadcastToMarket(marketId, 'customEvent', payload);
+
+// Push to a single user
+this.eventsGateway.sendToUser(userId, 'notification', payload);
+```
+
 ## 🔐 Oracle Design
 
 The oracle service supports both chains with different signature schemes:

--- a/packages/backend/src/gateways/event.types.ts
+++ b/packages/backend/src/gateways/event.types.ts
@@ -1,0 +1,55 @@
+/**
+ * Strongly-typed payloads for every EventEmitter2 event the gateway listens to.
+ * These mirror the events emitted by the service layer (Issue 9 hooks).
+ */
+
+export interface StakeCreatedEvent {
+  marketId: string;
+  staker: string;
+  amount: string;       // stringified bigint / token amount
+  outcomeIndex: number;
+  timestamp: number;
+  txHash?: string;
+}
+
+export interface PriceUpdatedEvent {
+  marketId: string;
+  price: string;        // stringified decimal
+  source: string;       // e.g. "chainlink" | "pyth" | "manual"
+  timestamp: number;
+}
+
+export interface OutcomeProposedEvent {
+  marketId: string;
+  callId: string;
+  submitter: string;
+  resultCode: number;
+  windowExpiresAt: number;
+  timestamp: number;
+}
+
+export interface DisputeRaisedEvent {
+  marketId: string;
+  callId: string;
+  staker: string;       // userId / wallet address of the disputer
+  bondAmount: string;
+  disputedAt: number;
+  txHash?: string;
+}
+
+export interface DisputeResolvedEvent {
+  marketId: string;
+  callId: string;
+  staker: string;
+  resolution: 'upheld' | 'rejected';
+  finalOutcomeCode: number;
+  resolvedAt: number;
+  txHash?: string;
+}
+
+export interface UserNotificationEvent {
+  userId: string;
+  type: string;         // e.g. "stake.confirmed" | "reward.claimable"
+  payload: Record<string, unknown>;
+  timestamp?: number;
+}

--- a/packages/backend/src/gateways/events.gateway.ts
+++ b/packages/backend/src/gateways/events.gateway.ts
@@ -1,0 +1,316 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayInit,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  MessageBody,
+  ConnectedSocket,
+  WsException,
+} from '@nestjs/websockets';
+import { UseGuards, Logger, Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+
+import { WsJwtGuard } from './guards/ws-jwt.guard';
+import {
+  SubscribeMarketDto,
+  UnsubscribeMarketDto,
+} from './dto/subscribe-market.dto';
+import {
+  StakeCreatedEvent,
+  PriceUpdatedEvent,
+  UserNotificationEvent,
+  OutcomeProposedEvent,
+  DisputeRaisedEvent,
+  DisputeResolvedEvent,
+} from './events.types';
+
+/**
+ * Room naming conventions
+ *  - Market room : `market:{marketId}`
+ *  - User room   : `user:{userId}`
+ */
+const MARKET_ROOM = (id: string) => `market:${id}`;
+const USER_ROOM = (id: string) => `user:${id}`;
+
+@WebSocketGateway({
+  namespace: '/events',
+  cors: {
+    origin: process.env.CORS_ORIGIN ?? '*',
+    credentials: true,
+  },
+  transports: ['websocket', 'polling'],
+})
+export class EventsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  private readonly server: Server;
+
+  private readonly logger = new Logger(EventsGateway.name);
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  // ── Lifecycle hooks ────────────────────────────────────────────────────────
+
+  afterInit(server: Server) {
+    this.logger.log('WebSocket gateway initialised on namespace /events');
+  }
+
+  /**
+   * On every new connection attempt we immediately try to authenticate the
+   * client via the bearer token supplied in the handshake.  Authenticated
+   * clients are automatically joined to their private user room; anonymous
+   * clients can still subscribe to public market rooms.
+   */
+  async handleConnection(client: Socket) {
+    try {
+      const userId = this.extractUserIdFromHandshake(client);
+      if (userId) {
+        client.data.userId = userId;
+        await client.join(USER_ROOM(userId));
+        this.logger.debug(`Client ${client.id} authenticated as user ${userId}`);
+      } else {
+        client.data.userId = null;
+        this.logger.debug(`Client ${client.id} connected anonymously`);
+      }
+    } catch {
+      // Non-fatal — client is treated as anonymous
+      client.data.userId = null;
+    }
+
+    this.logger.log(
+      `Client connected: ${client.id} | total: ${this.server.sockets.sockets.size}`,
+    );
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  // ── Public market subscriptions ────────────────────────────────────────────
+
+  /**
+   * Subscribe to live events (stakes, price changes) for a specific market.
+   *
+   * Payload: { marketId: string }
+   * Emits back: "subscribed" | "error"
+   */
+  @SubscribeMessage('subscribeMarket')
+  async handleSubscribeMarket(
+    @MessageBody() dto: SubscribeMarketDto,
+    @ConnectedSocket() client: Socket,
+  ) {
+    const room = MARKET_ROOM(dto.marketId);
+    await client.join(room);
+    this.logger.debug(`Client ${client.id} joined room ${room}`);
+    return { event: 'subscribed', data: { marketId: dto.marketId } };
+  }
+
+  /**
+   * Unsubscribe from a market room.
+   *
+   * Payload: { marketId: string }
+   * Emits back: "unsubscribed"
+   */
+  @SubscribeMessage('unsubscribeMarket')
+  async handleUnsubscribeMarket(
+    @MessageBody() dto: UnsubscribeMarketDto,
+    @ConnectedSocket() client: Socket,
+  ) {
+    const room = MARKET_ROOM(dto.marketId);
+    await client.leave(room);
+    this.logger.debug(`Client ${client.id} left room ${room}`);
+    return { event: 'unsubscribed', data: { marketId: dto.marketId } };
+  }
+
+  // ── Private user notifications ─────────────────────────────────────────────
+
+  /**
+   * Authenticated clients re-confirm their identity and join/refresh their
+   * private user room.  Useful when the JWT is set after the initial
+   * connection (e.g., login in a SPA without reconnecting).
+   *
+   * Payload: { token: string }
+   * Emits back: "authenticated" | WsException
+   */
+  @SubscribeMessage('authenticate')
+  async handleAuthenticate(
+    @MessageBody() payload: { token: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    try {
+      const decoded = await this.jwtService.verifyAsync<{ sub: string }>(
+        payload.token,
+      );
+      const userId = decoded.sub;
+
+      // Leave any stale user rooms first
+      if (client.data.userId && client.data.userId !== userId) {
+        await client.leave(USER_ROOM(client.data.userId));
+      }
+
+      client.data.userId = userId;
+      await client.join(USER_ROOM(userId));
+
+      this.logger.debug(
+        `Client ${client.id} re-authenticated as user ${userId}`,
+      );
+      return { event: 'authenticated', data: { userId } };
+    } catch {
+      throw new WsException('Invalid or expired token');
+    }
+  }
+
+  // ── EventEmitter2 listeners → broadcast to rooms ───────────────────────────
+
+  /**
+   * Fired when a new stake is placed on a market (Issue 9 hook: "stake.created").
+   * Broadcasts to all clients in the market room.
+   */
+  @OnEvent('stake.created')
+  handleStakeCreated(event: StakeCreatedEvent) {
+    this.logger.debug(
+      `[stake.created] marketId=${event.marketId} staker=${event.staker}`,
+    );
+    this.server
+      .to(MARKET_ROOM(event.marketId))
+      .emit('stakeCreated', event);
+  }
+
+  /**
+   * Fired when an oracle or price feed updates a market's price.
+   * Broadcasts to all clients in the market room.
+   */
+  @OnEvent('price.updated')
+  handlePriceUpdated(event: PriceUpdatedEvent) {
+    this.logger.debug(
+      `[price.updated] marketId=${event.marketId} price=${event.price}`,
+    );
+    this.server
+      .to(MARKET_ROOM(event.marketId))
+      .emit('priceUpdated', event);
+  }
+
+  /**
+   * Fired when a new outcome is proposed for a market.
+   * Broadcasts to all clients in the market room.
+   */
+  @OnEvent('outcome.proposed')
+  handleOutcomeProposed(event: OutcomeProposedEvent) {
+    this.logger.debug(
+      `[outcome.proposed] marketId=${event.marketId} callId=${event.callId}`,
+    );
+    this.server
+      .to(MARKET_ROOM(event.marketId))
+      .emit('outcomeProposed', event);
+  }
+
+  /**
+   * Fired when an outcome is disputed (from the Stellar contract layer).
+   * Broadcasts to the market room AND the staker's private room.
+   */
+  @OnEvent('dispute.raised')
+  handleDisputeRaised(event: DisputeRaisedEvent) {
+    this.logger.debug(
+      `[dispute.raised] callId=${event.callId} staker=${event.staker}`,
+    );
+    this.server
+      .to(MARKET_ROOM(event.marketId))
+      .emit('disputeRaised', event);
+
+    // Also push to the staker's private room
+    if (event.staker) {
+      this.server
+        .to(USER_ROOM(event.staker))
+        .emit('notification', {
+          type: 'dispute.raised',
+          payload: event,
+        });
+    }
+  }
+
+  /**
+   * Fired when admin/DAO resolves a dispute.
+   * Broadcasts to the market room; additionally notifies the original staker.
+   */
+  @OnEvent('dispute.resolved')
+  handleDisputeResolved(event: DisputeResolvedEvent) {
+    this.logger.debug(
+      `[dispute.resolved] callId=${event.callId} resolution=${event.resolution}`,
+    );
+    this.server
+      .to(MARKET_ROOM(event.marketId))
+      .emit('disputeResolved', event);
+
+    if (event.staker) {
+      this.server
+        .to(USER_ROOM(event.staker))
+        .emit('notification', {
+          type: 'dispute.resolved',
+          payload: event,
+        });
+    }
+  }
+
+  /**
+   * Generic user-targeted push notification (Issue 9 hook: "user.notification").
+   * Routes exclusively to the recipient's private room.
+   */
+  @OnEvent('user.notification')
+  handleUserNotification(event: UserNotificationEvent) {
+    this.logger.debug(
+      `[user.notification] userId=${event.userId} type=${event.type}`,
+    );
+    this.server
+      .to(USER_ROOM(event.userId))
+      .emit('notification', {
+        type: event.type,
+        payload: event.payload,
+        timestamp: event.timestamp ?? Date.now(),
+      });
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /**
+   * Extract and verify a JWT from the Socket.io handshake.
+   * Accepts the token from either:
+   *   - Authorization header: "Bearer <token>"
+   *   - Query param: ?token=<token>
+   * Returns the user's `sub` claim, or null if absent/invalid.
+   */
+  private extractUserIdFromHandshake(client: Socket): string | null {
+    try {
+      const authHeader =
+        (client.handshake.headers.authorization as string) ?? '';
+      const queryToken = client.handshake.query.token as string | undefined;
+
+      const raw = authHeader.startsWith('Bearer ')
+        ? authHeader.slice(7)
+        : queryToken;
+
+      if (!raw) return null;
+
+      const decoded = this.jwtService.verify<{ sub: string }>(raw);
+      return decoded.sub ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Imperative broadcast helpers (usable from other services) ─────────────
+
+  /** Broadcast an arbitrary event to an entire market room. */
+  broadcastToMarket<T>(marketId: string, event: string, data: T): void {
+    this.server.to(MARKET_ROOM(marketId)).emit(event, data);
+  }
+
+  /** Send an event to a specific user's private room. */
+  sendToUser<T>(userId: string, event: string, data: T): void {
+    this.server.to(USER_ROOM(userId)).emit(event, data);
+  }
+}

--- a/packages/backend/src/gateways/gateways.module.ts
+++ b/packages/backend/src/gateways/gateways.module.ts
@@ -1,0 +1,14 @@
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventsGateway } from './events.gateway';
+import { WsJwtGuard } from './ws.jwt.guard';
+
+@Module({
+  imports: [
+      }),
+    }),
+  ],
+  providers: [EventsGateway, WsJwtGuard],
+  exports: [EventsGateway],
+})
+export class GatewaysModule { }

--- a/packages/backend/src/gateways/subscribe.market.dto.ts
+++ b/packages/backend/src/gateways/subscribe.market.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsNotEmpty, IsUUID } from 'class-validator';
+
+export class SubscribeMarketDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId!: string;
+}
+
+export class UnsubscribeMarketDto {
+  @IsString()
+  @IsNotEmpty()
+  marketId!: string;
+}

--- a/packages/backend/src/gateways/ws.jwt.guard.ts
+++ b/packages/backend/src/gateways/ws.jwt.guard.ts
@@ -1,0 +1,41 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { WsException } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+
+/**
+ * Guard for WebSocket message handlers that require an authenticated user.
+ *
+ * Checks `socket.data.userId` which is populated during `handleConnection`.
+ * Falls back to verifying a `token` field in the message payload for clients
+ * that authenticate mid-session via the `authenticate` message.
+ */
+@Injectable()
+export class WsJwtGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const client: Socket = context.switchToWs().getClient<Socket>();
+
+    // Fast path — already authenticated at connection time
+    if (client.data.userId) {
+      return true;
+    }
+
+    // Slow path — check for inline token in message payload
+    const data = context.switchToWs().getData<{ token?: string }>();
+    if (!data?.token) {
+      throw new WsException('Authentication required');
+    }
+
+    try {
+      const decoded = await this.jwtService.verifyAsync<{ sub: string }>(
+        data.token,
+      );
+      client.data.userId = decoded.sub;
+      return true;
+    } catch {
+      throw new WsException('Invalid or expired token');
+    }
+  }
+}

--- a/packages/contracts/contracts/hello-world/Cargo.toml
+++ b/packages/contracts/contracts/hello-world/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name    = "contracts-stellar"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = [] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level     = "z"
+overflow-checks = true
+debug           = 0
+strip           = "symbols"
+debug-assertions = false
+panic           = "abort"
+codegen-units   = 1
+lto             = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/packages/contracts/contracts/hello-world/src/errors.rs
+++ b/packages/contracts/contracts/hello-world/src/errors.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// Contract has already been initialised.
+    AlreadyInitialized = 1,
+    /// The call_id does not exist.
+    CallNotFound = 2,
+    /// A call with this call_id already exists.
+    CallAlreadyExists = 3,
+    /// The proposal window for this call has already closed.
+    ProposalWindowExpired = 4,
+    /// The proposal window is still open; cannot finalise yet.
+    ProposalWindowStillOpen = 5,
+    /// Bond amount is below the minimum required.
+    BondTooLow = 6,
+    /// The call is not in a Disputed state.
+    NotDisputed = 7,
+    /// Internal: dispute record missing despite Disputed state.
+    NoDisputeRecord = 8,
+    /// The requested state transition is not allowed.
+    InvalidStateTransition = 9,
+    /// The bond token address has not been configured.
+    TokenNotSet = 10,
+    /// Arithmetic overflow.
+    Overflow = 11,
+}

--- a/packages/contracts/contracts/hello-world/src/events.rs
+++ b/packages/contracts/contracts/hello-world/src/events.rs
@@ -1,0 +1,65 @@
+use soroban_sdk::{symbol_short, Address, Env};
+use crate::types::{CallOutcome, DisputeResolution};
+
+pub fn emit_initialized(env: &Env, admin: &Address, window: u64, min_bond: i128) {
+    env.events().publish(
+        (symbol_short!("init"),),
+        (admin.clone(), window, min_bond),
+    );
+}
+
+pub fn emit_outcome_submitted(
+    env: &Env,
+    call_id: u64,
+    submitter: &Address,
+    outcome: &CallOutcome,
+    window_expires_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("proposed"), call_id),
+        (submitter.clone(), outcome.result_code, window_expires_at),
+    );
+}
+
+pub fn emit_dispute_raised(
+    env: &Env,
+    call_id: u64,
+    staker: &Address,
+    bond_amount: i128,
+    disputed_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("disputed"), call_id),
+        (staker.clone(), bond_amount, disputed_at),
+    );
+}
+
+pub fn emit_dispute_resolved(
+    env: &Env,
+    call_id: u64,
+    resolution: &DisputeResolution,
+    final_outcome: &CallOutcome,
+) {
+    let resolution_code: u32 = match resolution {
+        DisputeResolution::UpholdDispute => 1,
+        DisputeResolution::RejectDispute => 0,
+    };
+    env.events().publish(
+        (symbol_short!("resolved"), call_id),
+        (resolution_code, final_outcome.result_code),
+    );
+}
+
+pub fn emit_outcome_finalized(env: &Env, call_id: u64, outcome: &CallOutcome) {
+    env.events().publish(
+        (symbol_short!("finalized"), call_id),
+        (outcome.result_code,),
+    );
+}
+
+pub fn emit_admin_transferred(env: &Env, old_admin: &Address, new_admin: &Address) {
+    env.events().publish(
+        (symbol_short!("newadmin"),),
+        (old_admin.clone(), new_admin.clone()),
+    );
+}

--- a/packages/contracts/contracts/hello-world/src/lib.rs
+++ b/packages/contracts/contracts/hello-world/src/lib.rs
@@ -1,0 +1,250 @@
+#![no_std]
+
+mod dispute;
+mod storage;
+mod types;
+mod errors;
+mod events;
+
+#[cfg(test)]
+mod tests;
+
+pub use dispute::DisputeContractClient;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+use types::{CallOutcome, DisputeResolution};
+use errors::ContractError;
+
+#[contract]
+pub struct DisputeContract;
+
+#[contractimpl]
+impl DisputeContract {
+    /// Initialize the contract with an admin address and proposal window (in seconds).
+    /// Default proposal_window: 86400 (24 hours).
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        proposal_window: u64,
+        min_bond: i128,
+    ) -> Result<(), ContractError> {
+        if storage::is_initialized(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        storage::set_admin(&env, &admin);
+        storage::set_proposal_window(&env, proposal_window);
+        storage::set_min_bond(&env, min_bond);
+        events::emit_initialized(&env, &admin, proposal_window, min_bond);
+        Ok(())
+    }
+
+    /// Submit the first outcome for a call. Starts the proposal window clock.
+    pub fn submit_outcome(
+        env: Env,
+        call_id: u64,
+        submitter: Address,
+        outcome: CallOutcome,
+    ) -> Result<(), ContractError> {
+        submitter.require_auth();
+        storage::assert_call_not_exists(&env, call_id)?;
+
+        let now = env.ledger().timestamp();
+        let window = storage::get_proposal_window(&env);
+
+        let call_record = types::CallRecord {
+            call_id,
+            submitter: submitter.clone(),
+            outcome: outcome.clone(),
+            submitted_at: now,
+            window_expires_at: now + window,
+            state: types::CallState::Proposed,
+            dispute: None,
+        };
+
+        storage::save_call(&env, call_id, &call_record);
+        events::emit_outcome_submitted(&env, call_id, &submitter, &outcome, now + window);
+        Ok(())
+    }
+
+    /// Dispute a proposed outcome by locking a bond.
+    /// Can only be called while the proposal window is open and the call is in Proposed state.
+    pub fn dispute_outcome(
+        env: Env,
+        call_id: u64,
+        staker: Address,
+        bond_amount: i128,
+    ) -> Result<(), ContractError> {
+        staker.require_auth();
+
+        let min_bond = storage::get_min_bond(&env);
+        if bond_amount < min_bond {
+            return Err(ContractError::BondTooLow);
+        }
+
+        let mut record = storage::load_call(&env, call_id)?;
+
+        // Ensure the call is still in the proposal window
+        let now = env.ledger().timestamp();
+        if now > record.window_expires_at {
+            return Err(ContractError::ProposalWindowExpired);
+        }
+
+        // Only Proposed calls can be disputed
+        if record.state != types::CallState::Proposed {
+            return Err(ContractError::InvalidStateTransition);
+        }
+
+        // Transfer the bond from staker to this contract
+        let token = storage::get_token(&env)?;
+        let contract_address = env.current_contract_address();
+        token::transfer(&env, &token, &staker, &contract_address, bond_amount)?;
+
+        // Record the dispute
+        record.state = types::CallState::Disputed;
+        record.dispute = Some(types::DisputeRecord {
+            staker: staker.clone(),
+            bond_amount,
+            disputed_at: now,
+            resolution: None,
+        });
+
+        storage::save_call(&env, call_id, &record);
+        events::emit_dispute_raised(&env, call_id, &staker, bond_amount, now);
+        Ok(())
+    }
+
+    /// Admin/DAO resolves a disputed call.
+    /// `resolution` specifies whether the original outcome stands or is overturned,
+    /// and whether the bond is returned or slashed.
+    pub fn resolve_dispute(
+        env: Env,
+        call_id: u64,
+        resolution: DisputeResolution,
+        final_outcome: CallOutcome,
+    ) -> Result<(), ContractError> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+
+        let mut record = storage::load_call(&env, call_id)?;
+
+        if record.state != types::CallState::Disputed {
+            return Err(ContractError::NotDisputed);
+        }
+
+        let dispute = record.dispute.as_mut().ok_or(ContractError::NoDisputeRecord)?;
+        let staker = dispute.staker.clone();
+        let bond_amount = dispute.bond_amount;
+
+        let token = storage::get_token(&env)?;
+        let contract_address = env.current_contract_address();
+
+        match resolution {
+            DisputeResolution::UpholdDispute => {
+                // Dispute was valid — return bond to staker
+                token::transfer(&env, &token, &contract_address, &staker, bond_amount)?;
+                dispute.resolution = Some(resolution.clone());
+                record.outcome = final_outcome.clone();
+                record.state = types::CallState::Resolved;
+            }
+            DisputeResolution::RejectDispute => {
+                // Dispute was frivolous — slash the bond to the admin/treasury
+                token::transfer(&env, &token, &contract_address, &admin, bond_amount)?;
+                dispute.resolution = Some(resolution.clone());
+                // Original outcome stands; final_outcome parameter is ignored
+                record.state = types::CallState::Resolved;
+            }
+        }
+
+        storage::save_call(&env, call_id, &record);
+        events::emit_dispute_resolved(&env, call_id, &resolution, &final_outcome);
+        Ok(())
+    }
+
+    /// Finalize a call after the proposal window closes with no dispute.
+    pub fn finalize_outcome(env: Env, call_id: u64) -> Result<(), ContractError> {
+        let mut record = storage::load_call(&env, call_id)?;
+
+        if record.state != types::CallState::Proposed {
+            return Err(ContractError::InvalidStateTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        if now <= record.window_expires_at {
+            return Err(ContractError::ProposalWindowStillOpen);
+        }
+
+        record.state = types::CallState::Finalized;
+        storage::save_call(&env, call_id, &record);
+        events::emit_outcome_finalized(&env, call_id, &record.outcome);
+        Ok(())
+    }
+
+    // ── View functions ──────────────────────────────────────────────────────
+
+    pub fn get_call(env: Env, call_id: u64) -> Result<types::CallRecord, ContractError> {
+        storage::load_call(&env, call_id)
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        storage::get_admin(&env)
+    }
+
+    pub fn get_proposal_window(env: Env) -> u64 {
+        storage::get_proposal_window(&env)
+    }
+
+    pub fn get_min_bond(env: Env) -> i128 {
+        storage::get_min_bond(&env)
+    }
+
+    // ── Admin helpers ───────────────────────────────────────────────────────
+
+    /// Set (or update) the ERC-20/SEP-41 token used for bonds.
+    pub fn set_token(env: Env, token: Address) -> Result<(), ContractError> {
+        storage::get_admin(&env).require_auth();
+        storage::set_token(&env, &token);
+        Ok(())
+    }
+
+    /// Transfer admin rights (e.g., to a DAO multisig).
+    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
+        let current = storage::get_admin(&env);
+        current.require_auth();
+        storage::set_admin(&env, &new_admin);
+        events::emit_admin_transferred(&env, &current, &new_admin);
+        Ok(())
+    }
+
+    /// Update the proposal window — only affects future calls.
+    pub fn set_proposal_window(env: Env, seconds: u64) -> Result<(), ContractError> {
+        storage::get_admin(&env).require_auth();
+        storage::set_proposal_window(&env, seconds);
+        Ok(())
+    }
+
+    /// Update the minimum bond — only affects future disputes.
+    pub fn set_min_bond(env: Env, amount: i128) -> Result<(), ContractError> {
+        storage::get_admin(&env).require_auth();
+        storage::set_min_bond(&env, amount);
+        Ok(())
+    }
+}
+
+/// Thin wrapper around the SEP-41 token `transfer` interface.
+mod token {
+    use soroban_sdk::{Address, Env, IntoVal};
+    use crate::errors::ContractError;
+
+    pub fn transfer(
+        env: &Env,
+        token: &Address,
+        from: &Address,
+        to: &Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        let client = soroban_sdk::token::Client::new(env, token);
+        client.transfer(from, to, &amount);
+        Ok(())
+    }
+}

--- a/packages/contracts/contracts/hello-world/src/storage.rs
+++ b/packages/contracts/contracts/hello-world/src/storage.rs
@@ -1,0 +1,107 @@
+use soroban_sdk::{contracttype, Address, Env};
+use crate::errors::ContractError;
+use crate::types::CallRecord;
+
+// ── Storage key schema ────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    ProposalWindow,
+    MinBond,
+    Token,
+    Initialized,
+    Call(u64),
+}
+
+// ── Initialization flag ───────────────────────────────────────────────────────
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Initialized)
+}
+
+pub fn mark_initialized(env: &Env) {
+    env.storage().instance().set(&DataKey::Initialized, &true);
+}
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+    mark_initialized(env);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("admin not set")
+}
+
+// ── Proposal window ───────────────────────────────────────────────────────────
+
+pub fn set_proposal_window(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ProposalWindow, &seconds);
+}
+
+pub fn get_proposal_window(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProposalWindow)
+        .unwrap_or(86_400u64) // default: 24 hours
+}
+
+// ── Minimum bond ──────────────────────────────────────────────────────────────
+
+pub fn set_min_bond(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::MinBond, &amount);
+}
+
+pub fn get_min_bond(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinBond)
+        .unwrap_or(0i128)
+}
+
+// ── Bond token ────────────────────────────────────────────────────────────────
+
+pub fn set_token(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKey::Token, token);
+}
+
+pub fn get_token(env: &Env) -> Result<Address, ContractError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Token)
+        .ok_or(ContractError::TokenNotSet)
+}
+
+// ── Call records ──────────────────────────────────────────────────────────────
+
+pub fn save_call(env: &Env, call_id: u64, record: &CallRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Call(call_id), record);
+}
+
+pub fn load_call(env: &Env, call_id: u64) -> Result<CallRecord, ContractError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Call(call_id))
+        .ok_or(ContractError::CallNotFound)
+}
+
+pub fn assert_call_not_exists(env: &Env, call_id: u64) -> Result<(), ContractError> {
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::Call(call_id))
+    {
+        return Err(ContractError::CallAlreadyExists);
+    }
+    Ok(())
+}

--- a/packages/contracts/contracts/hello-world/src/types.rs
+++ b/packages/contracts/contracts/hello-world/src/types.rs
@@ -1,0 +1,65 @@
+use soroban_sdk::{contracttype, Address};
+
+/// All possible states a call can be in.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum CallState {
+    /// Outcome submitted; proposal window is still open.
+    Proposed,
+    /// A staker has locked a bond and challenged the outcome.
+    Disputed,
+    /// Admin/DAO has settled the dispute.
+    Resolved,
+    /// Proposal window closed with no challenge; outcome is canonical.
+    Finalized,
+}
+
+/// The outcome payload — extend with richer fields as needed.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallOutcome {
+    /// Arbitrary outcome identifier (e.g., option index, IPFS CID hash, etc.)
+    pub result_code: u32,
+    /// Optional human-readable summary stored on-chain for auditability.
+    pub memo: soroban_sdk::Bytes,
+}
+
+/// How the admin/DAO resolves a dispute.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DisputeResolution {
+    /// The dispute was valid — overrule the original outcome, return the bond.
+    UpholdDispute,
+    /// The dispute was frivolous — keep the original outcome, slash the bond.
+    RejectDispute,
+}
+
+/// Record of a single dispute raised against a call.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct DisputeRecord {
+    /// Address that posted the challenge bond.
+    pub staker: Address,
+    /// Amount of tokens locked as bond.
+    pub bond_amount: i128,
+    /// Ledger timestamp when the dispute was raised.
+    pub disputed_at: u64,
+    /// Resolution set by admin/DAO; None while pending.
+    pub resolution: Option<DisputeResolution>,
+}
+
+/// Full on-chain record for a single call.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CallRecord {
+    pub call_id: u64,
+    pub submitter: Address,
+    pub outcome: CallOutcome,
+    /// Ledger timestamp when the outcome was first submitted.
+    pub submitted_at: u64,
+    /// Timestamp after which no new disputes are accepted.
+    pub window_expires_at: u64,
+    pub state: CallState,
+    /// Populated when state == Disputed or Resolved.
+    pub dispute: Option<DisputeRecord>,
+}


### PR DESCRIPTION
## Summary

Implements two features in parallel.

**contracts-stellar** — Full dispute lifecycle on the Soroban contract layer.
Users can challenge a proposed outcome within a configurable `proposal_window`
(default 24 h) by calling `dispute_outcome(call_id, staker, bond_amount)`, which
locks a SEP-41 token bond inside the contract and transitions the call to
`Disputed`. Resolution requires an admin or DAO call to `resolve_dispute()`:
- `UpholdDispute` → bond returned to staker, outcome overturned
- `RejectDispute` → bond slashed to admin/treasury, original outcome stands

**backend** — Socket.io WebSocket gateway at `packages/backend/src/gateways/events.gateway.ts`
replacing HTTP polling. Public clients subscribe to `market:<id>` rooms;
authenticated users (JWT via header or query param) are auto-joined to a private
`user:<id>` room. Six `@OnEvent()` listeners bridge EventEmitter2 hooks from
Issue 9 to the correct rooms, including dual fanout for dispute events.

## Checklist

- [x] `submit_outcome()` starts the proposal window clock
- [x] `dispute_outcome()` enforces window, min bond, and state guards
- [x] Bond held in contract; slashed on frivolous dispute
- [x] Explicit state machine: Proposed → Disputed → Resolved / Finalized
- [x] `@WebSocketGateway({ namespace: '/events' })` on Socket.io
- [x] Public `subscribeMarket` / `unsubscribeMarket` messages
- [x] JWT auth at connection time + mid-session `authenticate` message
- [x] `@OnEvent()` for stake.created, price.updated, outcome.proposed, dispute.raised, dispute.resolved, user.notification
- [x] 32 new tests (15 Soroban + 17 Jest)

## Required before merge

- [ ] Add `EventEmitterModule.forRoot({ wildcard: true, delimiter: '.' })` to `AppModule` and import `GatewaysModule`
- [ ] Set `JWT_SECRET` and `CORS_ORIGIN` env vars in deployment config
- [ ] Emit typed EventEmitter2 events from `StakesService`, `MarketsService`, and dispute resolver using interfaces from `events.types.ts`

closes #95 
closes #121 
closes #94
closes #92