### PR TITLE
feat: add step-based staking progress (approve → stake) with UI stepper

### DIFF
--- a/packages/frontend/app/calls/[id]/page.tsx
+++ b/packages/frontend/app/calls/[id]/page.tsx
@@ -16,7 +16,7 @@ import { MarketDetailRightSidebarSkeleton } from "@/components/MarketDetailRight
 export default function CallDetailPage() {
     const params = useParams();
     const id = params?.id as string;
-    const { calls, stakeOnCall, isLoading } = useGlobalState();
+    const { calls, stakeOnCall, isLoading, stakingStep } = useGlobalState();
     const [stakingType, setStakingType] = useState<'back' | 'challenge' | null>(null);
     const [isFetching, setIsFetching] = useState(true);
 
@@ -34,6 +34,21 @@ export default function CallDetailPage() {
     }, [calls]);
 
     if (isFetching) {
+        const stepLabels: Record<string, string> = {
+            idle: "",
+            approving: "Step 1/2: Approving token…",
+            approved: "Step 1/2: Approval confirmed",
+            staking: "Step 2/2: Staking…",
+            confirmed: "Step 2/2: Confirmed",
+        };
+
+        const stepProgress: Record<string, number> = {
+            idle: 0,
+            approving: 25,
+            approved: 50,
+            staking: 75,
+            confirmed: 100,
+        };
         return (
             <AppLayout rightSidebar={<MarketDetailRightSidebarSkeleton />}>
                 <MarketDetailSkeleton />
@@ -115,8 +130,10 @@ export default function CallDetailPage() {
 
     return (
         <AppLayout rightSidebar={RightSidebar}>
-            {isLoading && <Loader text="Processing Transaction..." />}
-            
+            {isLoading && stakingStep !== "idle" && (
+                <Loader text={stepLabels[stakingStep] || "Processing transaction..."} />
+            )}
+
             {/* Header */}
             <header className="sticky top-0 z-40 bg-background/80 backdrop-blur-md border-b border-border px-4 py-3 flex items-center gap-4">
                 <Link href="/feed" className="p-2 hover:bg-secondary rounded-full transition-colors">
@@ -139,9 +156,9 @@ export default function CallDetailPage() {
             <div className="p-6">
                 {/* Price Chart Section */}
                 <section className="mb-8">
-                    <PriceChart 
-                        asset={call.asset || "Unknown"} 
-                        target={call.target || "TBD"} 
+                    <PriceChart
+                        asset={call.asset || "Unknown"}
+                        target={call.target || "TBD"}
                         startPrice={startPrice}
                         targetPrice={targetPrice}
                     />
@@ -196,25 +213,48 @@ export default function CallDetailPage() {
                             <h3 className="font-bold text-lg mb-2">
                                 Confirm {stakingType === 'back' ? 'Backing' : 'Challenge'}
                             </h3>
+
                             <p className="text-muted-foreground text-sm mb-4">
                                 You are about to stake 100 USDC on this prediction.
                             </p>
+
+                            {/* ✅ STEP INDICATOR */}
+                            {stakingStep !== "idle" && (
+                                <div className="mb-4">
+                                    <p className="text-sm font-medium mb-2">
+                                        {stepLabels[stakingStep]}
+                                    </p>
+
+                                    <div className="w-full bg-secondary rounded-full h-2 overflow-hidden">
+                                        <div
+                                            className="h-full bg-primary transition-all duration-500"
+                                            style={{ width: `${stepProgress[stakingStep]}%` }}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+
                             <div className="flex gap-3">
                                 <button
                                     onClick={() => setStakingType(null)}
-                                    className="flex-1 py-3 rounded-xl font-medium hover:bg-secondary transition-colors"
+                                    disabled={isLoading}
+                                    className="flex-1 py-3 rounded-xl font-medium hover:bg-secondary transition-colors disabled:opacity-50"
                                 >
                                     Cancel
                                 </button>
+
                                 <button
                                     onClick={async () => {
                                         await stakeOnCall(id, 100, stakingType);
                                         setStakingType(null);
                                     }}
-                                    className={`flex-1 py-3 rounded-xl font-bold text-white transition-colors ${stakingType === 'back' ? 'bg-green-500 hover:bg-green-600' : 'bg-red-500 hover:bg-red-600'
+                                    disabled={isLoading}
+                                    className={`flex-1 py-3 rounded-xl font-bold text-white transition-colors disabled:opacity-50 ${stakingType === 'back'
+                                            ? 'bg-green-500 hover:bg-green-600'
+                                            : 'bg-red-500 hover:bg-red-600'
                                         }`}
                                 >
-                                    Confirm Stake
+                                    {isLoading ? "Processing..." : "Confirm Stake"}
                                 </button>
                             </div>
                         </div>

--- a/packages/frontend/app/calls/[id]/page.tsx
+++ b/packages/frontend/app/calls/[id]/page.tsx
@@ -22,6 +22,21 @@ export default function CallDetailPage() {
 
     const call = calls.find(c => c.id === id);
 
+    const stepLabels: Record<string, string> = {
+  idle: "",
+  approving: "Step 1/2: Approving token…",
+  approved: "Step 1/2: Approval confirmed",
+  staking: "Step 2/2: Staking…",
+  confirmed: "Step 2/2: Confirmed",
+};
+
+const stepProgress: Record<string, number> = {
+  idle: 0,
+  approving: 25,
+  approved: 50,
+  staking: 75,
+  confirmed: 100,
+};
     // Simulate initial data fetching
     useEffect(() => {
         if (calls.length > 0) {
@@ -34,21 +49,6 @@ export default function CallDetailPage() {
     }, [calls]);
 
     if (isFetching) {
-        const stepLabels: Record<string, string> = {
-            idle: "",
-            approving: "Step 1/2: Approving token…",
-            approved: "Step 1/2: Approval confirmed",
-            staking: "Step 2/2: Staking…",
-            confirmed: "Step 2/2: Confirmed",
-        };
-
-        const stepProgress: Record<string, number> = {
-            idle: 0,
-            approving: 25,
-            approved: 50,
-            staking: 75,
-            confirmed: 100,
-        };
         return (
             <AppLayout rightSidebar={<MarketDetailRightSidebarSkeleton />}>
                 <MarketDetailSkeleton />
@@ -68,7 +68,7 @@ export default function CallDetailPage() {
     }
 
     // Parse stake amount for calculations
-    const stakeAmount = parseFloat(String(call.stake || "").split(" ")[0]) || 0;
+    // const stakeAmount = parseFloat(String(call.stake || "").split(" ")[0]) || 0;
     const startPrice = 0.12; // Mock start price
     const targetPrice = parseFloat(String(call.target || "").replace(/[^0-9.]/g, "")) || startPrice * 1.25;
 
@@ -131,7 +131,7 @@ export default function CallDetailPage() {
     return (
         <AppLayout rightSidebar={RightSidebar}>
             {isLoading && stakingStep !== "idle" && (
-                <Loader text={stepLabels[stakingStep] || "Processing transaction..."} />
+                <Loader text={stepLabels[stakingStep as keyof typeof stepLabels] || "Processing transaction..."} />
             )}
 
             {/* Header */}
@@ -228,7 +228,7 @@ export default function CallDetailPage() {
                                     <div className="w-full bg-secondary rounded-full h-2 overflow-hidden">
                                         <div
                                             className="h-full bg-primary transition-all duration-500"
-                                            style={{ width: `${stepProgress[stakingStep]}%` }}
+                                            style={{ width: `${stepProgress[stakingStep as keyof typeof stepProgress]}%` }}
                                         />
                                     </div>
                                 </div>

--- a/packages/frontend/components/GlobalState.tsx
+++ b/packages/frontend/components/GlobalState.tsx
@@ -16,6 +16,12 @@ import {
 import { useSocket, type SocketCallEvent } from '../hooks/useSocket';
 import { type Call, type User } from '../lib/types';
 
+type StakingStep =
+  | "idle"
+  | "approving"
+  | "approved"
+  | "staking"
+  | "confirmed";
 
 interface GlobalStateContextType {
   calls: Call[];
@@ -23,6 +29,7 @@ interface GlobalStateContextType {
   stakeOnCall: (callId: string, amount: number, type: 'back' | 'challenge') => Promise<void>;
   currentUser: User | null;
   isLoading: boolean;
+  stakingStep: StakingStep;
   login: () => Promise<void>;
   setPendingReferrerWallet: (referrerWallet: string | null) => void;
   updateProfile: (data: { handle: string; bio: string }) => Promise<void>;
@@ -65,6 +72,7 @@ const getErrorMessage = (error: unknown): string => {
 export function GlobalStateProvider({ children }: { children: React.ReactNode }) {
   const [calls, setCalls] = useState<Call[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [stakingStep, setStakingStep] = useState<StakingStep>("idle");
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [newCallsBanner, setNewCallsBanner] = useState(false);
   const [pendingReferrerWallet, setPendingReferrerWallet] = useState<
@@ -123,11 +131,11 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
         prev.map((c) =>
           c.id === (data.callOnchainId ?? data.id)
             ? {
-                ...c,
-                totalStakeYes: Number(data.totalStakeYes ?? c.totalStakeYes),
-                totalStakeNo: Number(data.totalStakeNo ?? c.totalStakeNo),
-                backers: (c.backers || 0) + 1,
-              }
+              ...c,
+              totalStakeYes: Number(data.totalStakeYes ?? c.totalStakeYes),
+              totalStakeNo: Number(data.totalStakeNo ?? c.totalStakeNo),
+              backers: (c.backers || 0) + 1,
+            }
             : c,
         ),
       );
@@ -242,6 +250,8 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
     confirmedTitle: string;
     failedTitle: string;
     write: () => Promise<Hash>;
+    onStart?: () => void;
+    onConfirmed?: () => void;
   }): Promise<Hash> => {
     let txHash: Hash | undefined;
     try {
@@ -249,7 +259,10 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
         throw new Error("Unable to access chain client. Please reconnect wallet.");
       }
 
+      params.onStart?.(); // ✅ NEW
+
       txHash = await params.write();
+
       showTxSubmittedToast({
         title: params.submittedTitle,
         description: "Waiting for onchain confirmation.",
@@ -261,6 +274,8 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       if (receipt.status !== "success") {
         throw new Error("Transaction was mined but reverted.");
       }
+
+      params.onConfirmed?.(); // ✅ NEW
 
       showTxConfirmedToast({
         title: params.confirmedTitle,
@@ -379,8 +394,14 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
     }
   };
 
-  const stakeOnCall = async (callId: string, amount: number, type: "back" | "challenge") => {
+  const stakeOnCall = async (
+    callId: string,
+    amount: number,
+    type: "back" | "challenge"
+  ) => {
     setIsLoading(true);
+    setStakingStep("idle");
+
     try {
       if (selectedChain === 'stellar') {
         showInfoToast({ title: "Coming soon", description: "Stellar staking is not implemented yet." });
@@ -391,10 +412,13 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       const tokenAddress = process.env.NEXT_PUBLIC_MOCK_TOKEN_ADDRESS as `0x${string}`;
       const registryAddress = process.env.NEXT_PUBLIC_CALL_REGISTRY_ADDRESS as `0x${string}`;
 
+      // STEP 1: APPROVE
       await trackEvmTransaction({
         submittedTitle: "Tx Submitted: Token approval",
         confirmedTitle: "Tx Confirmed: Token approval",
         failedTitle: "Tx Failed: Token approval",
+        onStart: () => setStakingStep("approving"),
+        onConfirmed: () => setStakingStep("approved"),
         write: () =>
           writeContractAsync({
             address: tokenAddress,
@@ -404,11 +428,15 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
           }),
       });
 
+      // STEP 2: STAKE
       const position = type === "back";
+
       await trackEvmTransaction({
         submittedTitle: "Tx Submitted: Stake on call",
         confirmedTitle: "Tx Confirmed: Stake on call",
         failedTitle: "Tx Failed: Stake on call",
+        onStart: () => setStakingStep("staking"),
+        onConfirmed: () => setStakingStep("confirmed"),
         write: () =>
           writeContractAsync({
             address: registryAddress,
@@ -418,11 +446,14 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
           }),
       });
 
+      // Optimistic UI update (unchanged)
       setCalls((prev) =>
         prev.map((call) => {
           if (call.id === callId) {
-            const currentVolume = parseFloat(String(call.volume || "").replace(/[^0-9.-]+/g, "")) || 0;
+            const currentVolume =
+              parseFloat(String(call.volume || "").replace(/[^0-9.-]+/g, "")) || 0;
             const newVolume = currentVolume + amount;
+
             return {
               ...call,
               backers: (call.backers || 0) + 1,
@@ -434,6 +465,7 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
       );
     } catch (error) {
       console.error("Failed to stake:", error);
+      setStakingStep("idle"); // reset on error
     } finally {
       setIsLoading(false);
     }
@@ -447,6 +479,7 @@ export function GlobalStateProvider({ children }: { children: React.ReactNode })
         stakeOnCall,
         currentUser,
         isLoading,
+        stakingStep,
         login,
         setPendingReferrerWallet,
         updateProfile,


### PR DESCRIPTION
Closes #184 

## 🚀 Multi-Step Staking Progress Indicator

### Problem
Staking currently executes two sequential on-chain transactions:
1. Token approval
2. Stake execution

However, the UI only exposes a single `isLoading` state, giving users no visibility into:
- Which step is in progress
- Why they are prompted to sign twice

---

### Solution
Introduced a step-based staking state and visual progress indicator.

---

### ✨ Changes

#### State Management
- Replaced single loading flag with: