### PR TITLE
fix: render profile join date from currentUser.createdAt (#188)

### DIFF
--- a/packages/frontend/app/profile/page.tsx
+++ b/packages/frontend/app/profile/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useGlobalState } from "@/components/GlobalState";
 import { useChain } from "@/components/ChainProvider";
+import { formatJoinedDate } from "@/lib/utils";
 
 import { CallCard } from "@/components/CallCard";
 
@@ -64,6 +65,7 @@ export default function ProfilePage() {
 
     const myCalls = calls.filter(call => call.creator?.wallet.toLowerCase() === currentUser.wallet.toLowerCase());
     const inviteLink = `${origin}/onboarding?ref=${encodeURIComponent(currentUser.wallet)}`;
+    const joinedDateLabel = formatJoinedDate(currentUser.createdAt);
 
     const copyInviteLink = async () => {
         try {
@@ -127,10 +129,12 @@ export default function ProfilePage() {
                                 <LinkIcon className="h-3 w-3" />
                                 <a href="#" className="hover:text-primary hover:underline">backit.xyz</a>
                             </div>
-                            <div className="flex items-center gap-1">
-                                <Calendar className="h-3 w-3" />
-                                Joined Nov 2025
-                            </div>
+                            {joinedDateLabel && (
+                                <div className="flex items-center gap-1">
+                                    <Calendar className="h-3 w-3" />
+                                    {joinedDateLabel}
+                                </div>
+                            )}
                         </div>
 
                         <div className="flex gap-4 mt-4 text-sm">

--- a/packages/frontend/lib/types.ts
+++ b/packages/frontend/lib/types.ts
@@ -7,6 +7,7 @@ export interface User {
   referredBy?: string;
   avatar?: string; // Legacy UI
   isFollowing?: boolean;
+  createdAt?: string;
 }
 
 export interface Call {

--- a/packages/frontend/lib/utils.ts
+++ b/packages/frontend/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
 }
+
+export function formatJoinedDate(
+    date?: string | Date | null,
+    locale: string = "en-US",
+): string | null {
+    if (!date) return null;
+    const parsed = date instanceof Date ? date : new Date(date);
+    if (Number.isNaN(parsed.getTime())) return null;
+    const formatted = new Intl.DateTimeFormat(locale, {
+        month: "short",
+        year: "numeric",
+    }).format(parsed);
+    return `Joined ${formatted}`;
+}

--- a/packages/frontend/src/components/ProfileHeader.test.tsx
+++ b/packages/frontend/src/components/ProfileHeader.test.tsx
@@ -262,12 +262,34 @@ describe('ProfileHeader Component', () => {
       expect(websiteLink).toHaveAttribute('href', 'https://backit.xyz');
     });
 
-    it('should display join date', () => {
+    it('should display join date derived from createdAt', () => {
+      const userWithCreatedAt: User = {
+        ...mockUser,
+        createdAt: '2025-03-15T12:00:00.000Z',
+      };
+      render(
+        <ProfileHeader user={userWithCreatedAt} socialStats={mockSocialStats} />
+      );
+      const joinDateInfo = screen.getByTestId('join-date-info');
+      expect(joinDateInfo).toHaveTextContent('Joined Mar 2025');
+    });
+
+    it('should not display join date when createdAt is missing', () => {
       render(
         <ProfileHeader user={mockUser} socialStats={mockSocialStats} />
       );
-      const joinDateInfo = screen.getByTestId('join-date-info');
-      expect(joinDateInfo).toHaveTextContent('Joined Nov 2025');
+      expect(screen.queryByTestId('join-date-info')).not.toBeInTheDocument();
+    });
+
+    it('should not display join date when createdAt is invalid', () => {
+      const userWithInvalidDate: User = {
+        ...mockUser,
+        createdAt: 'not-a-date',
+      };
+      render(
+        <ProfileHeader user={userWithInvalidDate} socialStats={mockSocialStats} />
+      );
+      expect(screen.queryByTestId('join-date-info')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/frontend/src/components/ProfileHeader.tsx
+++ b/packages/frontend/src/components/ProfileHeader.tsx
@@ -2,6 +2,7 @@
 
 import { User as UserIcon, MapPin, Calendar, Link as LinkIcon, Settings } from 'lucide-react';
 import React from 'react';
+import { formatJoinedDate } from '../../lib/utils';
 
 export interface User {
   wallet: string;
@@ -9,6 +10,7 @@ export interface User {
   handle?: string;
   bio?: string;
   avatar?: string;
+  createdAt?: string | Date;
 }
 
 export interface SocialStats {
@@ -31,6 +33,7 @@ export function ProfileHeader({
 }: ProfileHeaderProps) {
   const displayName = user.displayName || user.wallet.slice(0, 6);
   const chainName = currentChain === 'stellar' ? 'Stellar' : 'Base Sepolia';
+  const joinedDateLabel = formatJoinedDate(user.createdAt);
 
   return (
     <div className="w-full">
@@ -97,13 +100,15 @@ export function ProfileHeader({
                 backit.xyz
               </a>
             </div>
-            <div
-              className="flex items-center gap-1"
-              data-testid="join-date-info"
-            >
-              <Calendar className="h-3 w-3" />
-              Joined Nov 2025
-            </div>
+            {joinedDateLabel && (
+              <div
+                className="flex items-center gap-1"
+                data-testid="join-date-info"
+              >
+                <Calendar className="h-3 w-3" />
+                {joinedDateLabel}
+              </div>
+            )}
           </div>
 
           {/* Follow Stats */}


### PR DESCRIPTION
## Summary
- Closes #188 by removing the hardcoded `Joined Nov 2025` label on the Profile page and deriving `Joined {Month} {Year}` from `currentUser.createdAt` via `Intl.DateTimeFormat`.
- Adds a shared `formatJoinedDate` helper in `packages/frontend/lib/utils.ts`, gracefully hiding the row when `createdAt` is missing or invalid.
- Exposes `createdAt` on the frontend `User` type and on the `ProfileHeader` component (which is what the existing vitest suite covers); `/auth/login` already returns the column since the `User` entity has `@CreateDateColumn() createdAt: Date` and the controller returns the entity unchanged.

## Changes
- `packages/frontend/lib/utils.ts` — new `formatJoinedDate(date, locale?)` helper.
- `packages/frontend/lib/types.ts` — add `createdAt?: string` to `User`.
- `packages/frontend/app/profile/page.tsx` — read `currentUser.createdAt`, format it, hide when absent.
- `packages/frontend/src/components/ProfileHeader.tsx` — accept `createdAt` and render formatted label.
- `packages/frontend/src/components/ProfileHeader.test.tsx` — cover valid, missing, and invalid `createdAt` cases.

## Test plan
- [x] `pnpm --filter frontend test -- src/components/ProfileHeader.test.tsx` → 31/31 passing, including the new "Joined {Month} {Year}" assertion and the missing/invalid date cases.
- [x] `pnpm --filter frontend build` → succeeds (profile route compiles).
- [x] `pnpm --filter frontend lint` → no new errors (only pre-existing warnings).
- [ ] Manual: connect a wallet, load `/profile`, confirm the join date matches the account's actual creation month/year; disconnect and confirm no layout regressions.

Note: the `CallCard.test.tsx > should display creator wallet as fallback` failure reproduces on `main` and is unrelated to this change.