### PR TITLE
fix(portfolio): handle empty state and remove placeholder stakes in portfolio page

### DIFF
--- a/packages/frontend/app/portfolio/page.tsx
+++ b/packages/frontend/app/portfolio/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { AppLayout } from "@/components/AppLayout";
 import { TrendingUp, Award, Wallet } from 'lucide-react';
 import { useGlobalState } from "@/components/GlobalState";
@@ -20,58 +21,6 @@ interface Stake {
     payout?: number;
     result?: 'won' | 'lost';
 }
-
-// Placeholder stakes data
-const PLACEHOLDER_STAKES: Stake[] = [
-    {
-        id: '1',
-        title: 'ETH will reach $4000 by Feb 28',
-        choice: 'yes',
-        amount: 150,
-        chain: 'base',
-        timeLeft: '1d 5h',
-        status: 'active'
-    },
-    {
-        id: '2',
-        title: 'BTC will be above $65k',
-        choice: 'no',
-        amount: 250,
-        chain: 'base',
-        timeLeft: '7d 2h',
-        status: 'active'
-    },
-    {
-        id: '3',
-        title: 'Solana will outperform Ethereum',
-        choice: 'yes',
-        amount: 100,
-        payout: 180,
-        result: 'won',
-        chain: 'stellar',
-        status: 'settled'
-    },
-    {
-        id: '4',
-        title: 'XRP will reach $5 this month',
-        choice: 'no',
-        amount: 200,
-        payout: 0,
-        result: 'lost',
-        chain: 'base',
-        status: 'settled'
-    },
-    {
-        id: '5',
-        title: 'Polygon will reach $1.5',
-        choice: 'yes',
-        amount: 75,
-        payout: 112.5,
-        result: 'won',
-        chain: 'stellar',
-        status: 'claimable'
-    },
-];
 
 function getTimeRemaining(endTs: string | number): string {
     try {
@@ -97,7 +46,7 @@ function getTimeRemaining(endTs: string | number): string {
 export default function PortfolioPage() {
     const { currentUser } = useGlobalState();
     const [activeTab, setActiveTab] = useState<'active' | 'past' | 'claimable'>('active');
-    const [stakes, setStakes] = useState<Stake[]>(PLACEHOLDER_STAKES);
+    const [stakes, setStakes] = useState<Stake[]>([]);
     const [isLoading, setIsLoading] = useState(true);
 
     // Fetch user's stakes from backend
@@ -126,14 +75,14 @@ export default function PortfolioPage() {
                     }));
                     setStakes(processedStakes);
                 } else {
-                    // Fallback to placeholder if endpoint not available
-                    console.log('Stakes endpoint not available, using placeholder data');
-                    setStakes(PLACEHOLDER_STAKES);
+                    // Fallback to empty if endpoint not available
+                    console.log('Stakes endpoint not available, using empty data');
+                    setStakes([]);
                 }
             } catch (error) {
                 console.error('Failed to fetch stakes:', error);
-                // Use placeholder data on error
-                setStakes(PLACEHOLDER_STAKES);
+                // Use empty data on error
+                setStakes([]);
             } finally {
                 setIsLoading(false);
             }
@@ -313,12 +262,15 @@ export default function PortfolioPage() {
                             <StakeItem key={stake.id} stake={stake} />
                         ))
                     ) : (
-                        <div className="text-center py-12">
+                        <div className="text-center py-12 flex flex-col items-center justify-center">
                             <p className="text-muted-foreground mb-4">
-                                {activeTab === 'active' && 'No active stakes yet'}
-                                {activeTab === 'past' && 'No past stakes yet'}
-                                {activeTab === 'claimable' && 'No claimable payouts yet'}
+                                {activeTab === 'active' && 'No active stakes yet.'}
+                                {activeTab === 'past' && 'No past stakes yet.'}
+                                {activeTab === 'claimable' && 'No claimable payouts yet.'}
                             </p>
+                            <Link href="/explore" className="bg-primary text-white px-6 py-2 rounded-xl font-bold hover:bg-primary/90 transition-colors">
+                                Explore Markets
+                            </Link>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
## Description

This PR updates the Portfolio page (`app/portfolio/page.tsx`) to gracefully handle the absence of the user stakes backend endpoint (`/users/:wallet/stakes`), removing the previous reliance on hardcoded placeholder data. 

## Changes Made
- **Removed Hardcoded Data:** Deleted the `PLACEHOLDER_STAKES` array entirely.
- **Empty State Implementation:** When no stakes are found (or the backend returns a non-200 response), a proper empty state is now displayed.
- **Call To Action:** Added an "Explore Markets" CTA in the empty state that routes the user to the `/explore` page.
- **Loading State:** Skeleton loaders are now correctly displayed during the data fetch instead of instantly showing placeholder data.

## Why
The backend endpoint for user stakes does not exist yet. Instead of showing fake data to the user, the frontend should correctly handle the missing data gracefully and guide the user towards interacting with the application (exploring markets) until the API is fully implemented.

## Testing Instructions
1. Navigate to the Portfolio page.
2. Observe the skeleton loaders appear during the initial page load.
3. Once the fetch completes (and fails due to the missing endpoint), observe the empty state with the "Explore Markets" button.
4. Verify that clicking "Explore Markets" properly routes to the `/explore` page.

Closes https://github.com/degenspot/back-it-onchain/issues/186