### PR TITLE
feat: health check, real IPFS pinning, audit log entity, gateway broadcast methods

### DIFF
--- a/packages/backend/src/calls/calls.service.ts
+++ b/packages/backend/src/calls/calls.service.ts
@@ -3,9 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Call } from './call.entity';
 import { Participant } from './participant.entity';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
+import { IpfsService } from '../ipfs/ipfs.service';
 
 type CallsListOptions = {
   chain?: 'base' | 'stellar';
@@ -34,6 +32,7 @@ export class CallsService {
     private callsRepository: Repository<Call>,
     @InjectRepository(Participant)
     private participantsRepository: Repository<Participant>,
+    private readonly ipfsService: IpfsService,
   ) {}
 
   async create(callData: Partial<Call>): Promise<Call> {
@@ -104,28 +103,14 @@ export class CallsService {
   }
 
   async uploadIpfs(data: any): Promise<{ cid: string }> {
-    const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
-    if (!fs.existsSync(uploadsDir)) {
-      fs.mkdirSync(uploadsDir, { recursive: true });
-    }
-
-    const content = JSON.stringify(data);
-    const hash = crypto.createHash('sha256').update(content).digest('hex');
-    const cid = `Qm${hash.substring(0, 44)} `; // Mock CID format
-
-    fs.writeFileSync(path.join(uploadsDir, cid), content);
-    return Promise.resolve({ cid });
+    const buffer = Buffer.from(JSON.stringify(data));
+    const cid = await this.ipfsService.pin(buffer, 'data.json');
+    return { cid };
   }
 
   async getIpfs(cid: string): Promise<any> {
-    const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
-    const filePath = path.join(uploadsDir, cid);
-
-    if (fs.existsSync(filePath)) {
-      const content = fs.readFileSync(filePath, 'utf-8');
-      return Promise.resolve(JSON.parse(content));
-    }
-    return Promise.resolve(null);
+    const buffer = await this.ipfsService.fetch(cid);
+    return JSON.parse(buffer.toString('utf-8'));
   }
 
   async getStakesByWallet(wallet: string): Promise<any[]> {
@@ -141,7 +126,6 @@ export class CallsService {
       const isSettled = call.status === 'SETTLED' || call.outcome !== null;
       const hasEnded = new Date(call.endTs) <= now;
 
-      // Determine status
       let status: 'active' | 'settled' | 'claimable' = 'active';
       if (isSettled) {
         if (participant.position === call.outcome) {
@@ -153,15 +137,9 @@ export class CallsService {
         status = 'settled';
       }
 
-      // Calculate time left
-      const timeLeft = hasEnded
-        ? 'Ended'
-        : getTimeRemaining(call.endTs);
-
-      // Get call title from conditionJson or fallback
+      const timeLeft = hasEnded ? 'Ended' : getTimeRemaining(call.endTs);
       const callTitle = call.conditionJson?.title || `Market #${call.id}`;
 
-      // Calculate payout for winning stakes
       let payout: number | undefined;
       if (status === 'claimable') {
         const totalStakeYes = call.totalStakeYes || 0;
@@ -200,7 +178,7 @@ function getTimeRemaining(endTs: string | Date): string {
     const end = new Date(endTs);
     const diff = Math.max(0, end.getTime() - now.getTime());
 
-    if (diff === 0) return "Ended";
+    if (diff === 0) return 'Ended';
 
     const mins = Math.floor(diff / 60000);
     if (mins < 60) return `${mins}m`;
@@ -211,6 +189,6 @@ function getTimeRemaining(endTs: string | Date): string {
     const days = Math.floor(hrs / 24);
     return `${days}d`;
   } catch {
-    return "TBD";
+    return 'TBD';
   }
 }

--- a/packages/backend/src/gateways/events.gateway.ts
+++ b/packages/backend/src/gateways/events.gateway.ts
@@ -301,4 +301,16 @@ export class EventsGateway
   sendToUser<T>(userId: string, event: string, data: T): void {
     this.server.to(USER_ROOM(userId)).emit(event, data);
   }
+
+  emitCallCreated(callId: number, marketId: string): void {
+    this.server.to(MARKET_ROOM(String(marketId))).emit('call_created', { callId, marketId });
+  }
+
+  emitStakeAdded(marketId: string, stakeData: Record<string, unknown>): void {
+    this.server.to(MARKET_ROOM(marketId)).emit('stake_added', { marketId, ...stakeData });
+  }
+
+  emitOutcomeResolved(marketId: string, callId: string, outcome: unknown): void {
+    this.server.to(MARKET_ROOM(marketId)).emit('outcome_resolved', { marketId, callId, outcome });
+  }
 }

--- a/packages/backend/src/health/health.module.ts
+++ b/packages/backend/src/health/health.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheck,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+  MemoryHealthIndicator,
+} from '@nestjs/terminus';
+
+@Controller('health')
+class HealthController {
+  constructor(
+    private readonly health: HealthCheckService,
+    private readonly db: TypeOrmHealthIndicator,
+    private readonly memory: MemoryHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  check() {
+    return this.health.check([
+      () => this.db.pingCheck('database'),
+      () => this.memory.checkHeap('memory_heap', 200 * 1024 * 1024),
+    ]);
+  }
+}
+
+@Module({
+  imports: [TerminusModule, TypeOrmModule, HttpModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/packages/backend/src/oracle/audit-log.entity.ts
+++ b/packages/backend/src/oracle/audit-log.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  action: string;
+
+  @Column()
+  actor: string;
+
+  @Column({ nullable: true })
+  targetResource: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary

- Add `HealthModule` with a `GET /health` endpoint using `@nestjs/terminus` for database and memory probes
- Replace filesystem mock in `CallsService.uploadIpfs()` with real `IpfsService` (Kubo/Pinata) calls
- Add `AuditLog` TypeORM entity for persistent oracle action audit trails
- Add `emitCallCreated`, `emitStakeAdded`, and `emitOutcomeResolved` broadcast methods to `EventsGateway`

closes #214
closes #213
closes #212
closes #211